### PR TITLE
fix(sms): Staff-Invite SMS für Fahrschule Sara / Resend

### DIFF
--- a/migrations/20260805_sms_logs_purpose.sql
+++ b/migrations/20260805_sms_logs_purpose.sql
@@ -1,0 +1,14 @@
+-- Staff-invite / sendTenantSMS writes purpose on every sms_logs row.
+-- Production was missing this column → inserts failed (SMS may still send,
+-- but we lose delivery audit trail and debugging).
+
+ALTER TABLE sms_logs
+  ADD COLUMN IF NOT EXISTS purpose TEXT;
+
+COMMENT ON COLUMN sms_logs.purpose IS
+  'Purpose of SMS: staff_invite, student_onboarding, payment_reminder, appointment_reminder, etc.';
+
+CREATE INDEX IF NOT EXISTS idx_sms_logs_purpose ON sms_logs (purpose);
+CREATE INDEX IF NOT EXISTS idx_sms_logs_tenant_purpose_sent
+  ON sms_logs (tenant_id, purpose, sent_at DESC)
+  WHERE tenant_id IS NOT NULL;

--- a/server/api/staff/invite.post.ts
+++ b/server/api/staff/invite.post.ts
@@ -2,7 +2,7 @@ import { getSupabaseAdmin } from '~/utils/supabase'
 import { defineEventHandler, readBody, createError, getHeader } from 'h3'
 import { getAuthenticatedUser } from '~/server/utils/auth'
 import { logger } from '~/utils/logger'
-import { sendTenantSMS } from '~/server/utils/sms'
+import { sendTenantSMS, normalizePhoneNumber } from '~/server/utils/sms'
 import { checkRateLimit } from '~/server/utils/rate-limiter'
 import { logAudit } from '~/server/utils/audit'
 import { sanitizeString } from '~/server/utils/validators'
@@ -142,22 +142,111 @@ export default defineEventHandler(async (event) => {
 
     // ✅ LAYER 4: XSS Protection - Sanitize all string inputs
     const sanitizedFirstName = sanitizeString(firstName, 100)
-    const sanitizedPhone = sanitizeString(phone, 20)
+    const rawPhone = sanitizeString(phone, 30)
+    const sanitizedPhone = normalizePhoneNumber(rawPhone) || rawPhone
+    if (!normalizePhoneNumber(rawPhone)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Ungültige Telefonnummer'
+      })
+    }
 
-    // Check: existiert bereits eine offene Einladung für diese Telefonnummer?
-    const { data: existingInvite } = await serviceSupabase
+    // Generate invitation link base URL early (needed for resend + create)
+    const envBase = process.env.NUXT_PUBLIC_BASE_URL || process.env.BASE_URL
+    const forwardedHost = getHeader(event, 'x-forwarded-host')
+    const host = forwardedHost || getHeader(event, 'host')
+    const proto = getHeader(event, 'x-forwarded-proto') || 'https'
+    let baseUrl: string
+    if (envBase) {
+      baseUrl = envBase
+    } else if (host && !host.includes('localhost')) {
+      baseUrl = `${proto}://${host}`
+    } else {
+      baseUrl = 'https://app.simy.ch'
+    }
+
+    const { data: tenant } = await serviceSupabase
+      .from('tenants')
+      .select('name, contact_email, twilio_from_sender, slug, business_type')
+      .eq('id', userProfile.tenant_id)
+      .single()
+
+    const { getTerminologyDefaults } = await import('~/composables/useTerminology')
+    const terms = getTerminologyDefaults(tenant?.business_type)
+    const tenantName = tenant?.name || terms.businessNoun
+    const smsSenderName = tenant?.twilio_from_sender || tenantName
+    const loginLink = tenant?.slug ? `${baseUrl}/${tenant.slug}` : baseUrl
+
+    // Existing pending invite for this phone (any formatting) → resend SMS instead of 409
+    const { data: pendingInvites } = await serviceSupabase
       .from('staff_invitations')
-      .select('id, status')
-      .eq('phone', sanitizedPhone)
+      .select('id, status, phone, invitation_token, first_name, expires_at')
       .eq('tenant_id', userProfile.tenant_id)
       .eq('status', 'pending')
-      .maybeSingle()
+
+    const existingInvite = (pendingInvites || []).find((inv: any) => {
+      const invNorm = normalizePhoneNumber(inv.phone || '') || inv.phone
+      return invNorm === sanitizedPhone
+    })
 
     if (existingInvite) {
-      throw createError({
-        statusCode: 409,
-        statusMessage: 'Für diese Telefonnummer existiert bereits eine offene Einladung.'
-      })
+      // Extend expiry on resend
+      const expiresAt = new Date()
+      expiresAt.setDate(expiresAt.getDate() + 30)
+      await serviceSupabase
+        .from('staff_invitations')
+        .update({
+          first_name: sanitizedFirstName || existingInvite.first_name,
+          phone: sanitizedPhone,
+          expires_at: expiresAt.toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingInvite.id)
+
+      const inviteLink = `${baseUrl}/register/staff?token=${existingInvite.invitation_token}`
+      const nameForSms = sanitizedFirstName || existingInvite.first_name || ''
+      // Prefer GSM-7 (no umlauts) so the invite stays in fewer segments
+      const smsMessage = `Hallo ${nameForSms}! Du wurdest als ${terms.staff} bei ${tenantName} eingeladen. Registrierung: ${inviteLink}\nLogin: ${loginLink}`
+
+      try {
+        const smsResult = await sendTenantSMS({
+          tenantId: userProfile.tenant_id,
+          to: sanitizedPhone,
+          message: smsMessage,
+          purpose: 'staff_invite',
+          senderName: smsSenderName,
+        })
+        await logAudit({
+          action: 'staff_invitation_resent',
+          user_id: user.id,
+          tenant_id: userProfile.tenant_id,
+          resource_type: 'staff_invitation',
+          resource_id: existingInvite.id,
+          ip_address: ipAddress,
+          status: 'success',
+          details: { invited_phone: sanitizedPhone, resent: true, duration_ms: Date.now() - startTime }
+        }).catch(() => {})
+
+        return {
+          success: true,
+          resent: true,
+          sentVia: 'sms',
+          phone: sanitizedPhone,
+          inviteLink,
+          smsId: smsResult?.messageSid,
+          message: 'Einladung erneut per SMS gesendet'
+        }
+      } catch (smsError: any) {
+        console.error('❌ SMS resend failed:', smsError)
+        return {
+          success: true,
+          resent: true,
+          sentVia: 'sms_failed',
+          phone: sanitizedPhone,
+          inviteLink,
+          message: 'Offene Einladung vorhanden, SMS fehlgeschlagen. Link: ' + inviteLink
+        }
+      }
     }
 
     // Generate invitation token
@@ -215,45 +304,13 @@ export default defineEventHandler(async (event) => {
       }
     }).catch(err => logger.warn('⚠️ Could not log audit:', err))
 
-    // Generate invitation link
-    // Priority: 1. Environment variable, 2. Production domain (simy.ch), 3. Request host
-    const envBase = process.env.NUXT_PUBLIC_BASE_URL || process.env.BASE_URL
-    const forwardedHost = getHeader(event, 'x-forwarded-host')
-    const host = forwardedHost || getHeader(event, 'host')
-    const proto = getHeader(event, 'x-forwarded-proto') || 'https'
-    
-    // Prefer production URL over localhost
-    let baseUrl: string
-    if (envBase) {
-      baseUrl = envBase
-    } else if (host && !host.includes('localhost')) {
-      // Use request host only if it's NOT localhost
-      baseUrl = `${proto}://${host}`
-    } else {
-      // Default to production domain
-      baseUrl = 'https://app.simy.ch'
-    }
-    
     const inviteLink = `${baseUrl}/register/staff?token=${token}`
-
-    // Get tenant info for branding using service role
-    const { data: tenant } = await serviceSupabase
-      .from('tenants')
-      .select('name, contact_email, twilio_from_sender, slug, business_type')
-      .eq('id', userProfile.tenant_id)
-      .single()
-
-    const { getTerminologyDefaults } = await import('~/composables/useTerminology')
-    const terms = getTerminologyDefaults(tenant?.business_type)
-    const tenantName = tenant?.name || terms.businessNoun
-    const smsSenderName = tenant?.twilio_from_sender || tenantName
-    const loginLink = tenant?.slug ? `${baseUrl}/${tenant.slug}` : baseUrl
 
     // Send invitation via SMS
     logger.debug(`📱 Sending SMS to ${sanitizedPhone} with link: ${inviteLink}`)
 
     try {
-      const smsMessage = `Hallo ${sanitizedFirstName}! Sie wurden als ${terms.staff} bei ${tenantName} eingeladen. Registrierung: ${inviteLink}\nLogin nach Registrierung: ${loginLink}`
+      const smsMessage = `Hallo ${sanitizedFirstName}! Du wurdest als ${terms.staff} bei ${tenantName} eingeladen. Registrierung: ${inviteLink}\nLogin: ${loginLink}`
 
       const smsResult = await sendTenantSMS({
         tenantId: userProfile.tenant_id,

--- a/server/api/tenants/invite-staff-batch.post.ts
+++ b/server/api/tenants/invite-staff-batch.post.ts
@@ -5,7 +5,7 @@
 import { defineEventHandler, readBody, createError, getHeader } from 'h3'
 import { getSupabaseAdmin } from '~/utils/supabase'
 import { logger } from '~/utils/logger'
-import { sendTenantSMS } from '~/server/utils/sms'
+import { sendTenantSMS, normalizePhoneNumber } from '~/server/utils/sms'
 import { sendEmail } from '~/server/utils/email'
 import { sanitizeString } from '~/server/utils/validators'
 import { getPlanById } from '~/utils/planFeatures'
@@ -115,7 +115,8 @@ export default defineEventHandler(async (event) => {
   for (const entry of staff_list) {
     const firstName = sanitizeString(entry.first_name?.trim() || '', 100)
     const lastName  = sanitizeString(entry.last_name?.trim()  || '', 100)
-    const phone     = entry.phone?.trim() || null
+    const rawPhone  = entry.phone?.trim() || null
+    const phone     = rawPhone ? (normalizePhoneNumber(rawPhone) || rawPhone) : null
     const email     = entry.email?.trim().toLowerCase() || null
 
     if (!firstName) {
@@ -124,6 +125,10 @@ export default defineEventHandler(async (event) => {
     }
     if (!phone && !email) {
       results.push({ name: `${firstName} ${lastName}`, status: 'failed', message: 'Telefon oder E-Mail erforderlich' })
+      continue
+    }
+    if (rawPhone && !normalizePhoneNumber(rawPhone)) {
+      results.push({ name: `${firstName} ${lastName}`, status: 'failed', message: `Ungültige Telefonnummer: ${rawPhone}` })
       continue
     }
 
@@ -192,7 +197,8 @@ export default defineEventHandler(async (event) => {
     // ─── SMS senden ────────────────────────────────────────────────────────
     if (phone) {
       try {
-        const smsText = `Hallo ${firstName}! Willkommen bei ${tenantName}. Bitte vervollständige deine Registrierung als ${staffLabel}: ${inviteLink}`
+        // Keep message GSM-7 friendly (no umlauts) to avoid 3 UCS-2 segments
+        const smsText = `Hallo ${firstName}! Willkommen bei ${tenantName}. Bitte registriere dich als ${staffLabel}: ${inviteLink}`
         await sendTenantSMS({
           tenantId: tenant_id,
           to: phone,
@@ -204,9 +210,14 @@ export default defineEventHandler(async (event) => {
         logger.debug('✅ Onboarding-SMS gesendet an:', phone)
         continue
       } catch (smsErr: any) {
-        logger.warn('⚠️ SMS fehlgeschlagen für', phone, smsErr.message)
-        // Fallback: nur Einladungs-Link zurückgeben
-        results.push({ name: `${firstName} ${lastName}`, status: 'invited', message: `SMS fehlgeschlagen. Link: ${inviteLink}`, invite_link: inviteLink })
+        logger.warn('⚠️ SMS fehlgeschlagen für', phone, smsErr?.message || smsErr)
+        // Fallback: nur Einladungs-Link zurückgeben (UI shows this on success screen)
+        results.push({
+          name: `${firstName} ${lastName}`,
+          status: 'invited',
+          message: `SMS fehlgeschlagen (${smsErr?.message || 'unbekannt'}). Link: ${inviteLink}`,
+          invite_link: inviteLink,
+        })
         continue
       }
     }

--- a/server/utils/sms.ts
+++ b/server/utils/sms.ts
@@ -101,14 +101,32 @@ export async function sendSMS({ to, message, senderName }: SendSMSOptions) {
       logger.debug(`SMS using phone number: "${from}"`)
     }
     
-    const result = await client.messages.create({
-      body: message,
-      from: from,
-      to: normalizedTo
-    })
+    try {
+      const result = await client.messages.create({
+        body: message,
+        from: from,
+        to: normalizedTo
+      })
 
-    logger.debug('✅ SMS sent successfully:', result.sid)
-    return { success: true, messageSid: result.sid }
+      logger.debug('✅ SMS sent successfully:', result.sid)
+      return { success: true, messageSid: result.sid }
+    } catch (primaryError: any) {
+      // Alphanumeric sender IDs are often rejected/filtered if not pre-registered
+      // with the destination carrier. Retry once with the Twilio phone number.
+      if (from !== fromNumber) {
+        logger.warn(
+          `⚠️ SMS with sender "${from}" failed (${primaryError?.message || primaryError}); retrying with phone number`
+        )
+        const result = await client.messages.create({
+          body: message,
+          from: fromNumber,
+          to: normalizedTo
+        })
+        logger.debug('✅ SMS sent successfully on phone-number fallback:', result.sid)
+        return { success: true, messageSid: result.sid }
+      }
+      throw primaryError
+    }
   } catch (error) {
     console.error('❌ Error sending SMS:', error)
     throw error
@@ -183,17 +201,24 @@ export async function sendTenantSMS(opts: SendTenantSMSOptions): Promise<SendTen
   const smsResult = await sendSMS({ to, message, senderName: resolvedSender })
   const messageSid = smsResult.messageSid || `sms_${Date.now()}`
 
-  const { error: logError } = await supabase.from('sms_logs').insert({
+  const logRow: Record<string, unknown> = {
     tenant_id: tenantId,
     to_phone: normalizePhoneNumber(to) || to,
     message,
     twilio_sid: messageSid,
     status: 'sent',
-    purpose,
     segment_count: segmentCount,
     billable,
     sent_at: new Date().toISOString(),
-  })
+  }
+  // purpose column may be missing until migrations/20260805_sms_logs_purpose.sql is applied
+  if (purpose) logRow.purpose = purpose
+
+  let { error: logError } = await supabase.from('sms_logs').insert(logRow)
+  if (logError?.message?.includes('purpose') && 'purpose' in logRow) {
+    delete logRow.purpose
+    ;({ error: logError } = await supabase.from('sms_logs').insert(logRow))
+  }
   if (logError) {
     logger.warn('⚠️ sms_logs insert failed (non-critical):', logError.message)
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context
FAHRSCHULE Sara (`fahrschule-sara`) registered today and created a pending staff invite for **Sara Hernandez-Aemei** (`+41764229200`), but no staff-register SMS arrived. Invite is still `pending`; no staff user completed registration.

## Root cause (prod)
1. **Invite was created**, SMS path failed or was not auditable — onboarding catches Twilio errors and continues with status `invited` / manual link.
2. **`sms_logs.purpose` missing in production** — `sendTenantSMS` always writes `purpose`, so logging fails (confirmed via PostgREST `42703`). That hides whether Twilio accepted the message.
3. **No resend** — `/api/staff/invite` returned **409** for an open invite, so Admin could not retry SMS.
4. Likely contributor: alphanumeric sender `FS Sara` without phone-number fallback on Twilio reject; umlauts in batch SMS forced UCS-2 (3 segments).

## Fix
- Migration `migrations/20260805_sms_logs_purpose.sql` (+ resilient insert if column still missing)
- Twilio retry with `TWILIO_PHONE_NUMBER` when alphanumeric sender fails
- Pending invite → **resend SMS** instead of 409 (normalized phone match)
- GSM-friendlier invite copy; store E.164 phones

## Immediate unblock (already valid)
Staff register link for Sara:
`https://app.simy.ch/register/staff?token=zHnnZExlGhe03KVQDRu_Dbv74TZCQ5Qj`

## After merge
Run the purpose migration on Supabase, then from Sara’s admin UI invite the same phone again to resend SMS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd28e-b894-7a2a-b2a8-5dd565e6057d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd28e-b894-7a2a-b2a8-5dd565e6057d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

