### PR TITLE
Fix Android launch crash for Play Store resubmission

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -103,17 +103,29 @@ jobs:
           FIREBASE_CONFIGS: ${{ secrets.FIREBASE_CONFIGS }}
           CLIENT_ID: ${{ matrix.client }}
         run: |
-          if [ -n "$FIREBASE_CONFIGS" ]; then
-            B64=$(echo "$FIREBASE_CONFIGS" | jq -r --arg c "$CLIENT_ID" '.[$c] // empty')
-            if [ -n "$B64" ]; then
-              echo "$B64" | base64 --decode > android/app/google-services.json
-              echo "✅ google-services.json written for $CLIENT_ID"
-            else
-              echo "⚠️  No Firebase config found for $CLIENT_ID in FIREBASE_CONFIGS — Push Notifications may not work"
-            fi
-          else
-            echo "⚠️  FIREBASE_CONFIGS secret not set — Push Notifications may not work"
+          # PushNotifications is always compiled in. Without google-services.json
+          # FirebaseMessaging.getInstance() kills the process on launch (Play rejection).
+          if [ -z "$FIREBASE_CONFIGS" ]; then
+            echo "❌ FIREBASE_CONFIGS secret is missing — Android will crash on open"
+            exit 1
           fi
+          B64=$(echo "$FIREBASE_CONFIGS" | jq -r --arg c "$CLIENT_ID" '.[$c] // empty')
+          if [ -z "$B64" ]; then
+            echo "❌ No Firebase config for $CLIENT_ID in FIREBASE_CONFIGS — Android will crash on open"
+            exit 1
+          fi
+          echo "$B64" | base64 --decode > android/app/google-services.json
+          test -s android/app/google-services.json || { echo "❌ google-services.json is empty"; exit 1; }
+          python3 - <<'PY'
+          import json
+          data = json.load(open("android/app/google-services.json"))
+          packages = [
+            c.get("client_info", {}).get("android_client_info", {}).get("package_name")
+            for c in data.get("client", [])
+          ]
+          print("Firebase packages:", packages)
+          PY
+          echo "✅ google-services.json written for $CLIENT_ID"
 
       - name: Generate app icons
         env:
@@ -178,12 +190,12 @@ jobs:
         env:
           KEYSTORE_ALIAS: ${{ steps.config.outputs.keystore_alias }}
           KEYSTORE_PASSWORD: ${{ steps.keystore.outputs.keystore_password }}
-          VERSION_CODE: ${{ github.run_number }}
+          VERSION_NAME: ${{ steps.config.outputs.version }}
         run: |
           cd android
           # Patch versionCode using run number (starts at 1, always increments)
-          VERSION_CODE=$((github_run_number + 1))
           sed -i "s/versionCode [0-9]*/versionCode ${{ github.run_number }}/" app/build.gradle
+          sed -i "s/versionName \".*\"/versionName \"${VERSION_NAME}\"/" app/build.gradle
           cat >> app/build.gradle << 'EOF'
 
           android.signingConfigs {

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -274,7 +274,12 @@ jobs:
             });
             console.log(`Track ${track} updated`);
 
-            await publisher.edits.commit({ packageName, editId });
+            await publisher.edits.commit({
+              packageName,
+              editId,
+              // Required while the app has unresolved Play policy issues (e.g. rejected v19).
+              changesNotSentForReview: true,
+            });
             console.log('Release committed successfully!');
           }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,4 +58,5 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/android/app/src/main/java/ch/simy/app/MainActivity.java
+++ b/android/app/src/main/java/ch/simy/app/MainActivity.java
@@ -1,5 +1,13 @@
 package ch.simy.app;
 
+import android.os.Bundle;
+import androidx.core.splashscreen.SplashScreen;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        SplashScreen.installSplashScreen(this);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">#7C3AED</color>
+    <color name="colorPrimaryDark">#6D28D9</color>
+    <color name="colorAccent">#EC4899</color>
+    <color name="splash_background">#FFFFFF</color>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,12 @@
     </style>
 
 
+    <!-- Android 12+ SplashScreen API. postSplashScreenTheme is required or
+         AppCompat inflates under Theme.SplashScreen and the process dies after launch. -->
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash</item>
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+        <item name="android:windowSplashScreenBehavior">icon_preferred</item>
     </style>
 </resources>

--- a/plugins/push.client.ts
+++ b/plugins/push.client.ts
@@ -2,11 +2,15 @@
  * Nuxt client plugin — sets up Capacitor Push Notifications.
  * Runs only in the native app (iOS / Android); silently skips in the browser.
  *
+ * Do not register FCM on cold start. Without google-services.json,
+ * PushNotifications.register() kills the Android process. Play reviewers
+ * also never get past the login screen, so permission prompts belong after auth.
+ *
  * Flow:
- *  1. Check / request permission
- *  2. Register with FCM / APNs → receive device token
+ *  1. Attach listeners
+ *  2. After a session exists: request permission + register with FCM / APNs
  *  3. POST token to /api/push/register-token (authenticated)
- *  4. Listen for incoming notifications and taps
+ *  4. Handle incoming notifications and taps
  */
 
 import { defineNuxtPlugin, navigateTo } from '#imports'
@@ -17,24 +21,11 @@ export default defineNuxtPlugin(async () => {
 
   try {
     const { PushNotifications } = await import('@capacitor/push-notifications')
+    const supabase = useSupabaseClient()
+    let registered = false
 
-    // ── 1. Permission ─────────────────────────────────────────────────────────
-    let permStatus = await PushNotifications.checkPermissions()
-    if (permStatus.receive === 'prompt') {
-      permStatus = await PushNotifications.requestPermissions()
-    }
-    if (permStatus.receive !== 'granted') {
-      console.info('[Push] Permission not granted, skipping registration.')
-      return
-    }
-
-    // ── 2. Register with platform push service ────────────────────────────────
-    await PushNotifications.register()
-
-    // ── 3. Token received → save to backend ──────────────────────────────────
     await PushNotifications.addListener('registration', async (tokenData) => {
       try {
-        const supabase = useSupabaseClient()
         const { data: { session } } = await supabase.auth.getSession()
         if (!session?.access_token) return
 
@@ -51,17 +42,14 @@ export default defineNuxtPlugin(async () => {
       }
     })
 
-    // ── 4. Registration error ─────────────────────────────────────────────────
     await PushNotifications.addListener('registrationError', (err) => {
       console.error('[Push] Registration error:', JSON.stringify(err))
     })
 
-    // ── 5. Foreground notification (show as in-app banner via console for now) ─
     await PushNotifications.addListener('pushNotificationReceived', (notification) => {
       console.info('[Push] Foreground notification:', notification.title)
     })
 
-    // ── 6. Notification tap → navigate if data.path is a safe in-app path ───
     await PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
       const path = action.notification.data?.path as string | undefined
       if (
@@ -72,6 +60,31 @@ export default defineNuxtPlugin(async () => {
       ) {
         navigateTo(path)
       }
+    })
+
+    const registerIfAllowed = async () => {
+      if (registered) return
+      try {
+        let permStatus = await PushNotifications.checkPermissions()
+        if (permStatus.receive === 'prompt') {
+          permStatus = await PushNotifications.requestPermissions()
+        }
+        if (permStatus.receive !== 'granted') {
+          console.info('[Push] Permission not granted, skipping registration.')
+          return
+        }
+        await PushNotifications.register()
+        registered = true
+      } catch (e) {
+        console.warn('[Push] Native register failed (Firebase missing?):', e)
+      }
+    }
+
+    const { data: { session } } = await supabase.auth.getSession()
+    if (session) await registerIfAllowed()
+
+    supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (nextSession) registerIfAllowed()
     })
   } catch (e) {
     console.warn('[Push] Setup failed:', e)

--- a/scripts/generate-icons.mjs
+++ b/scripts/generate-icons.mjs
@@ -158,6 +158,22 @@ async function generateAndroidIcons() {
       .toFile(join(outDir, 'ic_launcher_foreground.png'))
   }
   console.log(`  ✅ ${ANDROID_ICONS.length} Android icon densities generated`)
+
+  // Brand colors for the launch theme (referenced by styles.xml)
+  const valuesDir = join(androidResDir, 'values')
+  mkdirSync(valuesDir, { recursive: true })
+  const primary = config.primaryColor || '#7C3AED'
+  const accent = config.accentColor || primary
+  const background = config.backgroundColor || '#ffffff'
+  writeFileSync(join(valuesDir, 'colors.xml'), `<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorPrimary">${primary}</color>
+    <color name="colorPrimaryDark">${primary}</color>
+    <color name="colorAccent">${accent}</color>
+    <color name="splash_background">${background}</color>
+</resources>
+`)
+  console.log('  ✅ Android colors.xml generated from client config')
 }
 
 async function generateSplashScreens() {


### PR DESCRIPTION
## Summary
- Play rejected version code 19 (Broken Functionality) because the July 3 AAB shipped without Firebase `google-services.json`, so the push plugin crashed the process on open.
- Require Firebase config in the Android CI build, defer FCM registration until login, and use a valid Android 12 splash theme (`postSplashScreenTheme`).

## Test plan
- [ ] GitHub Action **Build White-Label Android App** (`client=simy`, `track=internal`) succeeds and uploads version code 20+
- [ ] CI log shows `google-services.json written for simy`
- [ ] Install the internal-track build: app opens to the login screen and stays there (no crash)
- [ ] After login, notification permission can be granted without crashing
- [ ] Resubmit the new version in Play Console (no appeal needed)


Made with [Cursor](https://cursor.com)