### PR TITLE
Add Playwright login tests for Apple Review accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@
 # that must stay green — the local pre-push smoke-test is too slow to be
 # the only gate and is skippable with SKIP_SMOKE_TEST=1.
 #
-# Blocking today: unit tests + lint on the test suite (the only eslint
-# surface we can keep clean; the rest of the repo has hundreds of
-# pre-existing errors, mostly no-explicit-any).
+# Blocking today: unit tests + lint on the test suite, plus Playwright
+# login against the apple-review demo tenant (needs E2E_DEMO_PASSWORD).
 #
 # Report-only: npm audit. Production deps currently include unfixed
 # highs/criticals (xlsx has no patch; nuxt/vite pull more). Failing the
@@ -51,3 +50,29 @@ jobs:
       - name: Production dependency audit (report only)
         continue-on-error: true
         run: npm run audit:prod
+
+  e2e:
+    name: E2E login
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Apple Review login
+        env:
+          E2E_DEMO_PASSWORD: ${{ secrets.E2E_DEMO_PASSWORD }}
+          E2E_BASE_URL: https://app.simy.ch
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,11 @@ docs/pci/**/*.html
 .env.vercel.local
 .env.vercel.production
 .env.backfill
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 supabase/.temp/
 .env.vercel.pulled

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const password = process.env.E2E_DEMO_PASSWORD
+const loginPath = '/login?tenant=apple-review'
+
+test.beforeAll(() => {
+  if (process.env.CI && !password) {
+    throw new Error('E2E_DEMO_PASSWORD is not set. Add it as a GitHub Actions secret.')
+  }
+})
+
+async function signIn(page: Page, email: string) {
+  await page.goto(loginPath)
+  await page.locator('#email').waitFor({ state: 'visible', timeout: 30_000 })
+  await page.locator('#email').fill(email)
+  await page.locator('#password').fill(password || '')
+  await page.locator('form').getByRole('button', { name: 'Anmelden' }).click()
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 })
+}
+
+test.describe('apple-review login', () => {
+  test.skip(!password, 'E2E_DEMO_PASSWORD is not set')
+
+  test('customer reaches the dashboard', async ({ page }) => {
+    await signIn(page, 'apple-review@simy.ch')
+    await expect(page).toHaveURL(/customer-dashboard/)
+  })
+
+  test('admin reaches the admin area', async ({ page }) => {
+    await signIn(page, 'demo-admin@simy.ch')
+    await expect(page).toHaveURL(/\/admin/)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
       },
       "devDependencies": {
         "@nuxt/eslint": "^0.5.7",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^24.0.12",
         "@vitest/ui": "^2.0.0",
         "eslint": "^8.57.1",
@@ -8653,6 +8654,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -20543,6 +20560,53 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/plist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:watch": "vitest",
     "lint": "eslint \"server/utils/__tests__/**/*.ts\" --max-warnings 0",
     "audit:prod": "npm audit --omit=dev",
+    "test:e2e": "playwright test",
     "app:build": "bash scripts/build-client.sh",
     "app:icons": "node scripts/generate-icons.mjs",
     "app:bump": "bash scripts/bump-version.sh",
@@ -93,6 +94,7 @@
   },
   "devDependencies": {
     "@nuxt/eslint": "^0.5.7",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^24.0.12",
     "@vitest/ui": "^2.0.0",
     "eslint": "^8.57.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.E2E_BASE_URL || 'https://app.simy.ch'
+
+export default defineConfig({
+  testDir: 'e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 60_000,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})


### PR DESCRIPTION
## Summary
- Add Playwright and two login tests against the live `apple-review` tenant on `https://app.simy.ch` (customer + admin).
- New CI job `E2E login` uses the `E2E_DEMO_PASSWORD` GitHub secret. The password is not in the repo.
- Isolation (second tenant) is not in this PR — login is the first real end-to-end gate.

## Test plan
- [ ] Confirm `E2E login` is green on this PR (needs `E2E_DEMO_PASSWORD`)
- [ ] Confirm `Test and lint` still passes
- [ ] Optional locally: `E2E_DEMO_PASSWORD='…' npm run test:e2e`


Made with [Cursor](https://cursor.com)