### PR TITLE
Run E2E against the Vercel preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@
 # the only gate and is skippable with SKIP_SMOKE_TEST=1.
 #
 # Blocking today: unit tests + lint on the test suite, plus Playwright
-# login against the apple-review demo tenant (needs E2E_DEMO_PASSWORD).
+# login and tenant isolation. PRs hit the Vercel simy-app preview
+# (needs VERCEL_AUTOMATION_BYPASS_SECRET). Pushes to main stay on
+# https://app.simy.ch.
 #
 # Report-only: npm audit. Production deps currently include unfixed
 # highs/criticals (xlsx has no patch; nuxt/vite pull more). Failing the
@@ -21,6 +23,7 @@ concurrency:
 
 permissions:
   contents: read
+  deployments: read
 
 jobs:
   quality:
@@ -54,10 +57,18 @@ jobs:
   e2e:
     name: E2E login
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Wait for Vercel preview
+        id: preview
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          E2E_PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/wait-for-simy-preview.mjs
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -71,9 +82,15 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Apple Review login
+      - name: Playwright
         env:
           E2E_DEMO_PASSWORD: ${{ secrets.E2E_DEMO_PASSWORD }}
           E2E_ISOLATION_PASSWORD: ${{ secrets.E2E_ISOLATION_PASSWORD }}
-          E2E_BASE_URL: https://app.simy.ch
-        run: npm run test:e2e
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          E2E_BASE_URL: ${{ github.event_name == 'pull_request' && steps.preview.outputs.url || 'https://app.simy.ch' }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ -z "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            echo "VERCEL_AUTOMATION_BYPASS_SECRET is not set"
+            exit 1
+          fi
+          npm run test:e2e

--- a/e2e/auth.ts
+++ b/e2e/auth.ts
@@ -2,7 +2,21 @@ import { expect, type Page } from '@playwright/test'
 
 export const demoPassword = process.env.E2E_DEMO_PASSWORD
 
+/**
+ * Vercel Deployment Protection answers the first bypass request with a
+ * same-URL 307 plus `_vercel_jwt`. Seed that cookie before Chromium
+ * navigates so page.goto / page.request do not loop.
+ */
+async function unlockPreview(page: Page) {
+  if (!process.env.VERCEL_AUTOMATION_BYPASS_SECRET) return
+  await page.request.get('/api/health', {
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  })
+}
+
 export async function signIn(page: Page, email: string, tenantSlug: string, password = demoPassword) {
+  await unlockPreview(page)
   await page.goto(`/login?tenant=${tenantSlug}`)
   await page.locator('#email').waitFor({ state: 'visible', timeout: 30_000 })
   await page.locator('#email').fill(email)

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const baseURL = process.env.E2E_BASE_URL || 'https://app.simy.ch'
+const bypass = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
 
 export default defineConfig({
   testDir: 'e2e',
@@ -14,6 +15,12 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    extraHTTPHeaders: bypass
+      ? {
+          'x-vercel-protection-bypass': bypass,
+          'x-vercel-set-bypass-cookie': 'true',
+        }
+      : undefined,
   },
   projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 })

--- a/scripts/wait-for-simy-preview.mjs
+++ b/scripts/wait-for-simy-preview.mjs
@@ -1,0 +1,78 @@
+/**
+ * Wait for the Vercel "Preview – simy-app" deployment of a commit, then
+ * write its URL to GITHUB_OUTPUT. Used by CI so Playwright hits the PR
+ * build instead of production.
+ */
+import { appendFileSync } from 'node:fs'
+const repo = process.env.GITHUB_REPOSITORY
+const sha = process.env.E2E_PREVIEW_SHA
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+const timeoutMs = Number(process.env.E2E_PREVIEW_TIMEOUT_MS || 8 * 60 * 1000)
+const pollMs = 8000
+
+if (!repo || !sha || !token) {
+  console.error('Need GITHUB_REPOSITORY, E2E_PREVIEW_SHA, and GITHUB_TOKEN')
+  process.exit(1)
+}
+
+function isSimyAppPreview(environment) {
+  return /preview/i.test(environment || '') && /simy-app/i.test(environment || '')
+}
+
+async function gh(path) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`GitHub ${res.status} ${path}: ${text.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+function writeOutput(url) {
+  const dest = process.env.GITHUB_OUTPUT
+  if (dest) {
+    appendFileSync(dest, `url=${url}\n`)
+  }
+  console.log(`Preview ready: ${url}`)
+}
+
+const deadline = Date.now() + timeoutMs
+let lastState = 'none'
+
+while (Date.now() < deadline) {
+  const deployments = await gh(`/repos/${repo}/deployments?sha=${sha}&per_page=20`)
+  const candidates = deployments.filter((d) => isSimyAppPreview(d.environment))
+
+  if (candidates.length === 0) {
+    console.log(`No simy-app preview deployment yet for ${sha.slice(0, 7)}`)
+  }
+
+  for (const deployment of candidates) {
+    const statuses = await gh(
+      `/repos/${repo}/deployments/${deployment.id}/statuses`
+    )
+    const latest = statuses[0]
+    if (!latest) continue
+    lastState = `${deployment.environment}:${latest.state}`
+    if (latest.state === 'success' && latest.target_url) {
+      writeOutput(latest.target_url)
+      process.exit(0)
+    }
+    if (latest.state === 'failure' || latest.state === 'error') {
+      console.error(`Preview failed (${lastState})`)
+      process.exit(1)
+    }
+    console.log(`Waiting: ${lastState}`)
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, pollMs))
+}
+
+console.error(`Timed out waiting for simy-app preview (${lastState})`)
+process.exit(1)


### PR DESCRIPTION
## Summary
- On pull requests, Playwright waits for the `Preview – simy-app` deployment and runs login + isolation against that URL.
- Deployment Protection stays on. CI uses `VERCEL_AUTOMATION_BYPASS_SECRET` (`x-vercel-protection-bypass`).
- Pushes to `main` still test `https://app.simy.ch`.

## Test plan
- [ ] `E2E login` waits for the preview and is green
- [ ] Login and isolation still pass
- [ ] Opening the preview URL in a browser still shows the Vercel login wall


Made with [Cursor](https://cursor.com)