### PR TITLE
Fix preview E2E bypass on isolation contexts

### DIFF
--- a/e2e/auth.ts
+++ b/e2e/auth.ts
@@ -1,6 +1,20 @@
-import { expect, type Page } from '@playwright/test'
+import { expect, type Browser, type BrowserContext, type Page } from '@playwright/test'
 
 export const demoPassword = process.env.E2E_DEMO_PASSWORD
+
+export function previewBypassHeaders(): Record<string, string> | undefined {
+  const secret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+  if (!secret) return undefined
+  return {
+    'x-vercel-protection-bypass': secret,
+    'x-vercel-set-bypass-cookie': 'true',
+  }
+}
+
+export async function newE2EContext(browser: Browser): Promise<BrowserContext> {
+  const extraHTTPHeaders = previewBypassHeaders()
+  return extraHTTPHeaders ? browser.newContext({ extraHTTPHeaders }) : browser.newContext()
+}
 
 /**
  * Vercel Deployment Protection answers the first bypass request with a
@@ -8,8 +22,10 @@ export const demoPassword = process.env.E2E_DEMO_PASSWORD
  * navigates so page.goto / page.request do not loop.
  */
 async function unlockPreview(page: Page) {
-  if (!process.env.VERCEL_AUTOMATION_BYPASS_SECRET) return
+  const headers = previewBypassHeaders()
+  if (!headers) return
   await page.request.get('/api/health', {
+    headers,
     maxRedirects: 0,
     failOnStatusCode: false,
   })

--- a/e2e/isolation.spec.ts
+++ b/e2e/isolation.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { demoPassword, signIn } from './auth'
+import { demoPassword, newE2EContext, signIn } from './auth'
 
 const isolationPassword = process.env.E2E_ISOLATION_PASSWORD || demoPassword
 
@@ -20,7 +20,7 @@ test.describe('tenant isolation', () => {
   test.skip(!demoPassword || !isolationPassword, 'E2E passwords are not set')
 
   test('apple-review admin cannot read e2e-isolation users or appointments', async ({ browser }) => {
-    const isolation = await browser.newContext()
+    const isolation = await newE2EContext(browser)
     const isolationPage = await isolation.newPage()
     await signIn(isolationPage, 'e2e-isolation@simy.ch', 'e2e-isolation', isolationPassword)
 
@@ -39,7 +39,7 @@ test.describe('tenant isolation', () => {
 
     await isolation.close()
 
-    const apple = await browser.newContext()
+    const apple = await newE2EContext(browser)
     const applePage = await apple.newPage()
     await signIn(applePage, 'demo-admin@simy.ch', 'apple-review')
 

--- a/scripts/wait-for-simy-preview.mjs
+++ b/scripts/wait-for-simy-preview.mjs
@@ -4,6 +4,7 @@
  * build instead of production.
  */
 import { appendFileSync } from 'node:fs'
+
 const repo = process.env.GITHUB_REPOSITORY
 const sha = process.env.E2E_PREVIEW_SHA
 const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
@@ -53,21 +54,30 @@ while (Date.now() < deadline) {
     console.log(`No simy-app preview deployment yet for ${sha.slice(0, 7)}`)
   }
 
+  const states = []
   for (const deployment of candidates) {
     const statuses = await gh(
       `/repos/${repo}/deployments/${deployment.id}/statuses`
     )
     const latest = statuses[0]
     if (!latest) continue
-    lastState = `${deployment.environment}:${latest.state}`
-    if (latest.state === 'success' && latest.target_url) {
-      writeOutput(latest.target_url)
-      process.exit(0)
-    }
-    if (latest.state === 'failure' || latest.state === 'error') {
-      console.error(`Preview failed (${lastState})`)
-      process.exit(1)
-    }
+    states.push({
+      id: deployment.id,
+      state: latest.state,
+      url: latest.target_url,
+    })
+  }
+
+  const ready = states.find((row) => row.state === 'success' && row.url)
+  if (ready) {
+    writeOutput(ready.url)
+    process.exit(0)
+  }
+
+  lastState = states.map((row) => `${row.id}:${row.state}`).join(', ') || 'none'
+  if (states.some((row) => row.state === 'failure' || row.state === 'error')) {
+    console.log(`A preview failed; waiting for a later deploy (${lastState})`)
+  } else if (states.length > 0) {
     console.log(`Waiting: ${lastState}`)
   }
 


### PR DESCRIPTION
## Summary
- Isolation contexts now get `x-vercel-protection-bypass` explicitly, not only the default Playwright fixture.
- The preview waiter no longer exits on the first failed Vercel deploy for a SHA; it waits for a later success or times out.

## Test plan
- [ ] E2E login is green on this PR (preview + isolation)
- [ ] Test and lint is green


Made with [Cursor](https://cursor.com)