### PR TITLE
Fix drivingteam.ch sitemap 500 and empty blog index

### DIFF
--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -166,7 +166,6 @@ export default defineNuxtConfig({
       failOnError: false,
       routes: [
         '/',
-        '/blog/',
         '/blog/fuehrerschein-kosten-schweiz/',
         '/blog/bf17-begleitetes-fahren-schweiz/',
         '/blog/fuehrerschein-kategorien-schweiz/',
@@ -204,8 +203,8 @@ export default defineNuxtConfig({
 
     // Uster → vercel.json only (routeRules + vercel redirects = EEXIST symlink on Nitro/Vercel)
 
-    // ===== BLOG ARTIKEL – explizit prerendered =====
-    '/blog/': { prerender: true },
+    // Blog-Index nicht prerendern: Nitro schreibt sonst eine Datei `blog`
+    // (Meta-Refresh auf /blog/), die auf Vercel /blog/ überschreibt.
     '/blog/fuehrerschein-kosten-schweiz/': { prerender: true },
     '/blog/bf17-begleitetes-fahren-schweiz/': { prerender: true },
     '/blog/fuehrerschein-kategorien-schweiz/': { prerender: true },

--- a/apps/website/server/routes/sitemap.xml.ts
+++ b/apps/website/server/routes/sitemap.xml.ts
@@ -1,6 +1,6 @@
 import { SITEMAP_PATHS } from '../../data/sitemap-urls'
 
-export default defineEventHandler(() => {
+export default defineEventHandler((event) => {
   const urls = SITEMAP_PATHS.map(
     (e) => `  <url>
     <loc>https://drivingteam.ch${e.path}</loc>


### PR DESCRIPTION
## Summary
- Sitemap handler now receives `event`, so `/sitemap.xml` no longer 500s in production.
- Stop prerendering `/blog/` so Vercel does not serve the 92-byte meta-refresh stub instead of the real index.

## Test plan
- [ ] `https://drivingteam.ch/sitemap.xml` returns 200 with ~100 `<loc>` entries
- [ ] `https://drivingteam.ch/blog/` returns a real HTML page with title
- [ ] Blog articles still 200


Made with [Cursor](https://cursor.com)