### PR TITLE
fix: marketing cron GET, click-ID handoff, and first-party CPA

### DIFF
--- a/apps/website/components/GeneralInquiryForm.vue
+++ b/apps/website/components/GeneralInquiryForm.vue
@@ -556,6 +556,7 @@ const submitInquiry = async () => {
       // First-party DB log so inquiry forms appear in booking_redirects alongside booking clicks
       const sessionId = (window as any).__analyticsSessionId || 'unknown'
       const urlParams = new URLSearchParams(window.location.search)
+      const attr = (window as any).__dtMarketingAttribution ?? {}
       fetch('/api/booking-redirect', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -563,10 +564,13 @@ const submitInquiry = async () => {
           session_id: sessionId,
           category: label,
           referrer_page: window.location.pathname,
-          utm_source: urlParams.get('utm_source') || null,
-          utm_medium: urlParams.get('utm_medium') || null,
-          utm_campaign: urlParams.get('utm_campaign') || null,
-          utm_content: urlParams.get('utm_content') || null,
+          utm_source: attr.utm_source || urlParams.get('utm_source') || null,
+          utm_medium: attr.utm_medium || urlParams.get('utm_medium') || null,
+          utm_campaign: attr.utm_campaign || urlParams.get('utm_campaign') || null,
+          utm_content: attr.utm_content || urlParams.get('utm_content') || null,
+          gclid: attr.gclid || urlParams.get('gclid') || null,
+          gbraid: attr.gbraid || urlParams.get('gbraid') || null,
+          wbraid: attr.wbraid || urlParams.get('wbraid') || null,
         }),
       }).catch(() => {})
 

--- a/apps/website/composables/useBookingUrl.ts
+++ b/apps/website/composables/useBookingUrl.ts
@@ -99,8 +99,13 @@ export const useBookingUrl = () => {
     // Marketing attribution (gclid + UTMs) — encoded blob for cross-domain forwarding
     // Always attempt — even when no BookingParams were passed (bare generateBookingUrl()).
     if (typeof window !== 'undefined' && (window as any).__dtMarketingAttribution) {
-      const encoded = encodeAttribution((window as any).__dtMarketingAttribution)
+      const attr = (window as any).__dtMarketingAttribution
+      const encoded = encodeAttribution(attr)
       if (encoded) queryParams.append('dt_attr', encoded)
+      // Raw click IDs as a fallback if dt_attr is dropped by a redirect/proxy.
+      for (const key of ['gclid', 'gbraid', 'wbraid', 'fbclid'] as const) {
+        if (attr[key] && !queryParams.has(key)) queryParams.append(key, attr[key])
+      }
     }
 
     // Referrer — current page URL so the booking page can navigate back

--- a/apps/website/pages/auto-fahrschule-zuerich-preis.vue
+++ b/apps/website/pages/auto-fahrschule-zuerich-preis.vue
@@ -130,12 +130,12 @@ useHead({
 function trackPhone() {
   if (typeof window === 'undefined') return
   try {
-    const attr = (window as any).__marketingAttribution || {}
+    const attr = (window as any).__dtMarketingAttribution || {}
     fetch('/api/phone-click', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        session_id: attr.session_id || 'unknown',
+        session_id: (window as any).__analyticsSessionId || 'unknown',
         marketing_attribution: attr,
         referrer_page: '/auto-fahrschule-zuerich-preis/',
         utm_content: 'ag_preis',

--- a/apps/website/pages/auto-fahrschule-zuerich-probe.vue
+++ b/apps/website/pages/auto-fahrschule-zuerich-probe.vue
@@ -137,12 +137,12 @@ useHead({
 function trackPhone() {
   if (typeof window === 'undefined') return
   try {
-    const attr = (window as any).__marketingAttribution || {}
+    const attr = (window as any).__dtMarketingAttribution || {}
     fetch('/api/phone-click', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        session_id: attr.session_id || 'unknown',
+        session_id: (window as any).__analyticsSessionId || 'unknown',
         marketing_attribution: attr,
         referrer_page: '/auto-fahrschule-zuerich-probe/',
         utm_content: 'ag_probe',

--- a/apps/website/plugins/ga-events.client.ts
+++ b/apps/website/plugins/ga-events.client.ts
@@ -76,6 +76,7 @@ export default defineNuxtPlugin(() => {
       gclid: attr.gclid || p.get('gclid') || null,
       gbraid: attr.gbraid || p.get('gbraid') || null,
       wbraid: attr.wbraid || p.get('wbraid') || null,
+      fbclid: attr.fbclid || p.get('fbclid') || null,
     }
   }
 

--- a/apps/website/server/routes/go/buchen.get.ts
+++ b/apps/website/server/routes/go/buchen.get.ts
@@ -57,11 +57,14 @@ export default defineEventHandler(async (event) => {
 
   const sessionId = `${Date.now()}_${Math.random().toString(36).substring(2, 11)}`
 
+  const fbclid = str(query.fbclid)
   const attribution: AttributionFields & { landing_page?: string | null } = {
     gclid: str(query.gclid),
     gbraid: str(query.gbraid),
     wbraid: str(query.wbraid),
-    utm_source: str(query.utm_source) ?? 'google',
+    fbclid,
+    fbc: fbclid ? `fb.1.${Date.now()}.${fbclid}` : null,
+    utm_source: str(query.utm_source) ?? (fbclid ? 'facebook' : 'google'),
     utm_medium: str(query.utm_medium) ?? 'cpc',
     utm_campaign: str(query.utm_campaign),
     utm_content: str(query.utm_content),
@@ -80,6 +83,8 @@ export default defineEventHandler(async (event) => {
           gclid: attribution.gclid,
           gbraid: attribution.gbraid,
           wbraid: attribution.wbraid,
+          fbclid: attribution.fbclid,
+          fbc: attribution.fbc,
           utm_source: attribution.utm_source,
           utm_medium: attribution.utm_medium,
           utm_campaign: attribution.utm_campaign,
@@ -99,6 +104,10 @@ export default defineEventHandler(async (event) => {
   const dtAttr = encodeAttributionServer(attribution)
   const params = new URLSearchParams({ category, session_id: sessionId })
   if (dtAttr) params.set('dt_attr', dtAttr)
+  for (const key of ['gclid', 'gbraid', 'wbraid', 'fbclid'] as const) {
+    const value = attribution[key]
+    if (value) params.set(key, value)
+  }
 
   return sendRedirect(event, `${BOOKING_BASE_URL}?${params.toString()}`, 302)
 })

--- a/apps/website/utils/enrich-simy-url.ts
+++ b/apps/website/utils/enrich-simy-url.ts
@@ -51,6 +51,18 @@ export function enrichSimyUrl(href: string, options?: { referrer?: string | null
     if (blob && !url.searchParams.has('dt_attr')) {
       url.searchParams.set('dt_attr', blob)
     }
+
+    // First-class click IDs survive even if dt_attr is stripped or session_id
+    // is reminted on app.simy.ch — the booking plugin reads these from the URL.
+    const attr = getWebsiteAttribution()
+    if (attr) {
+      for (const key of ['gclid', 'gbraid', 'wbraid', 'fbclid'] as const) {
+        const value = attr[key]
+        if (value && !url.searchParams.has(key)) {
+          url.searchParams.set(key, value)
+        }
+      }
+    }
     if (metaConsentGiven && !url.searchParams.has('mc')) {
       url.searchParams.set('mc', '1')
     }

--- a/pages/marketing.vue
+++ b/pages/marketing.vue
@@ -640,7 +640,7 @@ const totalSessions = computed(() => {
   return data.value.ga4.reduce((sum: number, r: any) => sum + (r.sessions ?? 0), 0)
 })
 
-const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Referral', 'Organic Social', 'Email', 'Affiliates']
+const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Paid Social', 'Referral', 'Organic Social', 'Email', 'Affiliates']
 
 const totalConversions = computed(() => {
   if (!data.value?.ga4) return 0

--- a/plugins/booking-session-tracking.client.ts
+++ b/plugins/booking-session-tracking.client.ts
@@ -132,6 +132,15 @@ export default defineNuxtPlugin(() => {
     attribution = decodeAttribution(dtAttr)
   }
 
+  const readCookie = (name: string): string | null => {
+    try {
+      const match = document.cookie.match(new RegExp('(?:^|;\\s*)' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]+)'))
+      return match ? decodeURIComponent(match[1]) : null
+    } catch {
+      return null
+    }
+  }
+
   const urlHasClickId = !!(gclidFromUrl || gbraidFromUrl || wbraidFromUrl || fbclidFromUrl)
   if (urlHasClickId || urlParams.get('utm_source')) {
     const fromUrl: DecodedAttribution = {
@@ -164,8 +173,19 @@ export default defineNuxtPlugin(() => {
     }
   }
 
+  const fbcCookie = readCookie('_fbc')
+  const fbpCookie = readCookie('_fbp')
+  if (attribution && (fbcCookie || fbpCookie)) {
+    attribution = {
+      ...attribution,
+      fbc: attribution.fbc || fbcCookie,
+      fbp: attribution.fbp || fbpCookie,
+    }
+  }
+
   const hasPaidOrUtm = !!(
     attribution?.gclid || attribution?.gbraid || attribution?.wbraid || attribution?.fbclid
+    || attribution?.fbc || attribution?.fbp
     || (attribution?.utm_source && attribution.utm_source !== 'direct' && attribution.utm_source !== 'drivingteam_direct')
   )
   if (attribution && hasPaidOrUtm) {

--- a/plugins/booking-session-tracking.client.ts
+++ b/plugins/booking-session-tracking.client.ts
@@ -93,67 +93,85 @@ export default defineNuxtPlugin(() => {
   let isNewSession = false
 
   const dtAttr = urlParams.get('dt_attr')
-  // Direct click IDs in URL — present when Google Ads links directly to app.simy.ch
-  // instead of going through drivingteam.ch (which would produce a dt_attr blob).
+  // First-class click IDs — website now appends these in addition to dt_attr so
+  // they survive if the blob is stripped or a new session is minted on simy.
   const gclidFromUrl = urlParams.get('gclid')
   const gbraidFromUrl = urlParams.get('gbraid')
   const wbraidFromUrl = urlParams.get('wbraid')
+  const fbclidFromUrl = urlParams.get('fbclid')
 
-  if (dtAttr) {
-    attribution = decodeAttribution(dtAttr)
-    if (attribution) {
-      try {
-        localStorage.setItem(ATTR_KEY, JSON.stringify(attribution))
-      } catch {
-        // localStorage may be unavailable — fail silently
-      }
-      // Persist server-side so it can be joined to the appointment later.
-      fetch('/api/marketing-attribution', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_id: sessionId, tenant_id: window.__tenantId ?? null, attribution }),
-      }).catch(() => {})
-    }
-  } else if (gclidFromUrl || gbraidFromUrl || wbraidFromUrl) {
-    // Fallback: Google Ads linked directly to app.simy.ch with ?gclid= in the URL.
-    // Build the attribution from the raw click-ID params so the booking conversion
-    // can still be uploaded server-side.
-    attribution = {
-      gclid: gclidFromUrl ?? null,
-      gbraid: gbraidFromUrl ?? null,
-      wbraid: wbraidFromUrl ?? null,
-      fbclid: null,
-      fbc: null,
-      fbp: null,
-      utm_source: urlParams.get('utm_source') ?? 'google',
-      utm_medium: urlParams.get('utm_medium') ?? 'cpc',
-      utm_campaign: urlParams.get('utm_campaign') ?? null,
-      utm_content: urlParams.get('utm_content') ?? null,
-      utm_term: urlParams.get('utm_term') ?? null,
-      landing_page: window.location.pathname,
-    }
+  const persistAttribution = (attr: DecodedAttribution) => {
     try {
-      localStorage.setItem(ATTR_KEY, JSON.stringify(attribution))
+      localStorage.setItem(ATTR_KEY, JSON.stringify(attr))
     } catch {
-      // ignore
+      // localStorage may be unavailable — fail silently
     }
     fetch('/api/marketing-attribution', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ session_id: sessionId, tenant_id: window.__tenantId ?? null, attribution }),
+      body: JSON.stringify({ session_id: sessionId, tenant_id: window.__tenantId ?? null, attribution: attr }),
     }).catch(() => {})
-  } else {
+  }
+
+  const mergeClickIds = (base: DecodedAttribution | null, incoming: DecodedAttribution): DecodedAttribution => ({
+    gclid: incoming.gclid || base?.gclid || null,
+    gbraid: incoming.gbraid || base?.gbraid || null,
+    wbraid: incoming.wbraid || base?.wbraid || null,
+    fbclid: incoming.fbclid || base?.fbclid || null,
+    fbc: incoming.fbc || base?.fbc || null,
+    fbp: incoming.fbp || base?.fbp || null,
+    utm_source: incoming.utm_source || base?.utm_source || null,
+    utm_medium: incoming.utm_medium || base?.utm_medium || null,
+    utm_campaign: incoming.utm_campaign || base?.utm_campaign || null,
+    utm_content: incoming.utm_content || base?.utm_content || null,
+    utm_term: incoming.utm_term || base?.utm_term || null,
+    landing_page: incoming.landing_page || base?.landing_page || null,
+  })
+
+  if (dtAttr) {
+    attribution = decodeAttribution(dtAttr)
+  }
+
+  const urlHasClickId = !!(gclidFromUrl || gbraidFromUrl || wbraidFromUrl || fbclidFromUrl)
+  if (urlHasClickId || urlParams.get('utm_source')) {
+    const fromUrl: DecodedAttribution = {
+      gclid: gclidFromUrl,
+      gbraid: gbraidFromUrl,
+      wbraid: wbraidFromUrl,
+      fbclid: fbclidFromUrl,
+      fbc: fbclidFromUrl ? `fb.1.${Date.now()}.${fbclidFromUrl}` : null,
+      fbp: null,
+      utm_source: urlParams.get('utm_source') ?? (urlHasClickId ? (fbclidFromUrl ? 'facebook' : 'google') : null),
+      utm_medium: urlParams.get('utm_medium') ?? (urlHasClickId ? 'cpc' : null),
+      utm_campaign: urlParams.get('utm_campaign'),
+      utm_content: urlParams.get('utm_content'),
+      utm_term: urlParams.get('utm_term'),
+      landing_page: window.location.pathname,
+    }
+    attribution = mergeClickIds(attribution, fromUrl)
+  }
+
+  if (!attribution) {
     try {
       const stored = localStorage.getItem(ATTR_KEY)
       if (stored) {
         attribution = JSON.parse(stored) as DecodedAttribution
       } else {
-        // No attribution from drivingteam.ch — mark as direct so we always have a source
         isNewSession = true
       }
     } catch {
       isNewSession = true
     }
+  }
+
+  const hasPaidOrUtm = !!(
+    attribution?.gclid || attribution?.gbraid || attribution?.wbraid || attribution?.fbclid
+    || (attribution?.utm_source && attribution.utm_source !== 'direct' && attribution.utm_source !== 'drivingteam_direct')
+  )
+  if (attribution && hasPaidOrUtm) {
+    persistAttribution(attribution)
+  } else if (!attribution) {
+    isNewSession = true
   }
 
   // Persist direct-traffic sessions so they also appear in marketing_attributions.

--- a/server/api/admin/update-booking-proposal-status.post.ts
+++ b/server/api/admin/update-booking-proposal-status.post.ts
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
       .from('booking_proposals')
       .select(`
         id, tenant_id, staff_id, status, email, phone, category_code, created_by_user_id,
-        gclid, gbraid, wbraid, outcome_type
+        gclid, gbraid, wbraid, fbclid, fbc, fbp, outcome_type
       `)
       .eq('id', proposalId)
       .eq('tenant_id', tenantId)
@@ -109,7 +109,7 @@ export default defineEventHandler(async (event) => {
     if (
       outcomeType === 'booking_confirmed'
       && existingProposal.outcome_type !== 'booking_confirmed'
-      && (existingProposal.gclid || existingProposal.gbraid || existingProposal.wbraid)
+      && (existingProposal.gclid || existingProposal.gbraid || existingProposal.wbraid || existingProposal.fbclid)
     ) {
       try {
         adsUpload = await uploadProposalDerivedBookingConversion({
@@ -119,6 +119,9 @@ export default defineEventHandler(async (event) => {
             gclid: existingProposal.gclid,
             gbraid: existingProposal.gbraid,
             wbraid: existingProposal.wbraid,
+            fbclid: existingProposal.fbclid,
+            fbc: existingProposal.fbc,
+            fbp: existingProposal.fbp,
             email: existingProposal.email,
             phone: existingProposal.phone,
           },

--- a/server/api/booking/create-appointment.post.ts
+++ b/server/api/booking/create-appointment.post.ts
@@ -44,7 +44,8 @@ import { calculateAdminFee } from '~/server/utils/admin-fee'
 import { resolveVehicleSettings, calculateVehicleCost } from '~/server/utils/vehicle-availability'
 import { resolveRoomSettings, pickAvailableRoomId, type RoomServiceType } from '~/server/utils/room-availability'
 import { logFallbackUsed } from '~/server/utils/log-fallback'
-import { mergeAttributionFields } from '~/server/utils/marketing-attribution-merge'
+import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
+import { hasAnyAttribution } from '~/server/utils/marketing-attribution-merge'
 
 interface MarketingAttributionPayload {
   gclid?: string | null
@@ -533,31 +534,12 @@ export default defineEventHandler(async (event: H3Event) => {
     })
     
     // Prefer client payload; always merge DB + booking_redirects by session so
-    // Fahrstunden bookings keep gclid when only session_id crossed domains.
-    let marketingAttr: MarketingAttributionPayload | null = body.marketing_attribution ?? null
-    if (body.marketing_session_id) {
-      const { data: attrRow } = await supabase
-        .from('marketing_attributions')
-        .select('gclid, gbraid, wbraid, fbclid, fbc, fbp, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-        .eq('session_id', body.marketing_session_id)
-        .maybeSingle()
-      if (attrRow) {
-        marketingAttr = mergeAttributionFields(attrRow, marketingAttr) as MarketingAttributionPayload
-      }
-
-      if (!marketingAttr?.gclid && !marketingAttr?.gbraid && !marketingAttr?.wbraid) {
-        const { data: redirectRow } = await supabase
-          .from('booking_redirects')
-          .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-          .eq('session_id', body.marketing_session_id)
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .maybeSingle()
-        if (redirectRow) {
-          marketingAttr = mergeAttributionFields(marketingAttr, redirectRow) as MarketingAttributionPayload
-        }
-      }
-    }
+    // Fahrstunden bookings keep gclid/fbclid when only session_id crossed domains.
+    const marketingAttr = await resolveMarketingAttribution(
+      supabase,
+      body.marketing_session_id,
+      body.marketing_attribution,
+    )
 
     // Auto-assign a room (never chosen by the customer) — pick the first free
     // room from the admin-configured pool for this category+location+service type.
@@ -1169,7 +1151,7 @@ export default defineEventHandler(async (event: H3Event) => {
     // For new customers only, and only if not already set.
     // This lets us attribute ALL future bookings and revenue back to the original
     // marketing source — enabling true LTV-per-channel analysis.
-    if (isNewCustomer && (marketingAttr || body.marketing_session_id)) {
+    if (isNewCustomer && (hasAnyAttribution(marketingAttr) || body.marketing_session_id)) {
       ;(async () => {
         try {
           // Resolve referrer page from booking_redirects if we have a marketing_session_id

--- a/server/api/booking/create-appointment.post.ts
+++ b/server/api/booking/create-appointment.post.ts
@@ -1097,37 +1097,34 @@ export default defineEventHandler(async (event: H3Event) => {
     }
 
     // ============ LAYER 11b: META CONVERSIONS API (CAPI) UPLOAD ============
-    // Fire-and-forget. Sends a Purchase event to Meta's CAPI even when the browser
-    // Pixel fires too — Meta deduplicates via event_id. Requires at least one user
-    // signal (fbclid, fbc, fbp, email, or phone) to be meaningful.
-    ;(async () => {
-      try {
-        const normalizedEmail = (userData.email ?? '').trim().toLowerCase()
-        const normalizedPhone = (userData.phone ?? '').replace(/\s+/g, '').replace(/^00/, '+')
-        const hashedEmail = normalizedEmail ? await sha256Hex(normalizedEmail) : null
-        const hashedPhone = normalizedPhone.startsWith('+') ? await sha256Hex(normalizedPhone) : null
+    // Awaited: Vercel freezes the isolate after the response. Pixel still fires
+    // in the browser — Meta deduplicates via event_id.
+    try {
+      const normalizedEmail = (userData.email ?? '').trim().toLowerCase()
+      const normalizedPhone = (userData.phone ?? '').replace(/\s+/g, '').replace(/^00/, '+')
+      const hashedEmail = normalizedEmail ? await sha256Hex(normalizedEmail) : null
+      const hashedPhone = normalizedPhone.startsWith('+') ? await sha256Hex(normalizedPhone) : null
 
-        const conversionValueChf = (netAmountRappen > 0 ? netAmountRappen : totalAmountRappen) / 100
+      const conversionValueChf = (netAmountRappen > 0 ? netAmountRappen : totalAmountRappen) / 100
 
-        await recordAndSendCapiEvent({
-          appointment_id: newAppointment.id,
-          tenant_id: tenantId ?? null,
-          event_name: 'Purchase',
-          conversion_value_chf: conversionValueChf,
-          conversion_date_time: new Date(),
-          fbclid: marketingAttr?.fbclid ?? null,
-          fbc: marketingAttr?.fbc ?? null,
-          fbp: marketingAttr?.fbp ?? null,
-          hashed_email: hashedEmail,
-          hashed_phone: hashedPhone,
-          client_ip: ipAddress ?? null,
-          user_agent: getHeader(event, 'user-agent') ?? null,
-          event_source_url: getHeader(event, 'referer') ?? null,
-        })
-      } catch (err: any) {
-        logger.warn('⚠️ Meta CAPI upload failed (non-critical):', err?.message ?? err)
-      }
-    })()
+      await recordAndSendCapiEvent({
+        appointment_id: newAppointment.id,
+        tenant_id: tenantId ?? null,
+        event_name: 'Purchase',
+        conversion_value_chf: conversionValueChf,
+        conversion_date_time: new Date(),
+        fbclid: marketingAttr?.fbclid ?? null,
+        fbc: marketingAttr?.fbc ?? null,
+        fbp: marketingAttr?.fbp ?? null,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+        client_ip: ipAddress ?? null,
+        user_agent: getHeader(event, 'user-agent') ?? null,
+        event_source_url: getHeader(event, 'referer') ?? null,
+      })
+    } catch (err: any) {
+      logger.warn('⚠️ Meta CAPI upload failed (non-critical):', err?.message ?? err)
+    }
 
     // ============ LAYER 12: LINK booking_events.completed TO APPOINTMENT ============
     // Closes the first-party funnel so we can answer "which marketing session

--- a/server/api/booking/guest-book.post.ts
+++ b/server/api/booking/guest-book.post.ts
@@ -22,7 +22,7 @@
 import { defineEventHandler, readBody, createError } from 'h3'
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { DEFAULT_BOOKING_POLICY } from '~/server/api/admin/booking-policy.get'
-import { mergeAttributionFields } from '~/server/utils/marketing-attribution-merge'
+import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
 import { sendTenantSMS } from '~/server/utils/sms'
 import { sendEmail } from '~/server/utils/email'
 import { roundToNearest5Rappen } from '~/utils/rounding'
@@ -301,7 +301,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // ── Parallel: pricing + marketing attribution + location name ────────────
-  const [pricingResult, eventPricingResult, attrResult, locationResult] = await Promise.all([
+  const [pricingResult, eventPricingResult, marketingAttr, locationResult] = await Promise.all([
     supabase
       .from('pricing_rules')
       .select('price_per_minute_rappen, duration_multiplier, weekend_multiplier, evening_multiplier, admin_fee_rappen, admin_fee_applies_from')
@@ -323,13 +323,7 @@ export default defineEventHandler(async (event) => {
       .limit(1)
       .maybeSingle(),
 
-    body.marketing_session_id
-      ? supabase
-          .from('marketing_attributions')
-          .select('gclid, gbraid, wbraid, fbclid, fbc, fbp, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-          .eq('session_id', body.marketing_session_id)
-          .maybeSingle()
-      : Promise.resolve({ data: null }),
+    resolveMarketingAttribution(supabase, body.marketing_session_id, body.marketing_attribution),
 
     supabase
       .from('locations')
@@ -339,24 +333,6 @@ export default defineEventHandler(async (event) => {
   ])
 
   const pricingRule = pricingResult.data || eventPricingResult.data
-  let marketingAttr = body.marketing_attribution ?? null
-  if (body.marketing_session_id) {
-    if (attrResult.data) {
-      marketingAttr = mergeAttributionFields(attrResult.data, marketingAttr)
-    }
-    if (!marketingAttr?.gclid && !marketingAttr?.gbraid && !marketingAttr?.wbraid) {
-      const { data: redirectRow } = await supabase
-        .from('booking_redirects')
-        .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-        .eq('session_id', body.marketing_session_id)
-        .order('created_at', { ascending: false })
-        .limit(1)
-        .maybeSingle()
-      if (redirectRow) {
-        marketingAttr = mergeAttributionFields(marketingAttr, redirectRow)
-      }
-    }
-  }
   const location = locationResult.data
 
   // ── Calculate lesson price ────────────────────────────────────────────────

--- a/server/api/booking/guest-book.post.ts
+++ b/server/api/booking/guest-book.post.ts
@@ -673,23 +673,25 @@ export default defineEventHandler(async (event) => {
   }
 
   // ── Google Ads + Meta CAPI conversion (awaited — Vercel freezes after response)
-  try {
-    const hashedEmail = email ? await sha256Hex(email.toLowerCase().trim()) : null
-    const hashedPhone = phone ? await sha256Hex(formatSwissPhoneNumber(phone)) : null
+  if (marketingAttr?.gclid || marketingAttr?.gbraid || marketingAttr?.wbraid) {
+    try {
+      const hashedEmail = email ? await sha256Hex(email.toLowerCase().trim()) : null
+      const hashedPhone = phone ? await sha256Hex(formatSwissPhoneNumber(phone)) : null
 
-    await recordAndUploadConversion({
-      appointment_id: newAppointment.id,
-      tenant_id: tenantId,
-      gclid: marketingAttr?.gclid ?? null,
-      gbraid: marketingAttr?.gbraid ?? null,
-      wbraid: marketingAttr?.wbraid ?? null,
-      conversion_date_time: new Date(),
-      conversion_value_chf: grossAmountRappen / 100,
-      hashed_email: hashedEmail,
-      hashed_phone: hashedPhone,
-    })
-  } catch (e: any) {
-    logger.warn('⚠️ Google Ads conversion upload failed (guest):', e.message)
+      await recordAndUploadConversion({
+        appointment_id: newAppointment.id,
+        tenant_id: tenantId,
+        gclid: marketingAttr?.gclid ?? null,
+        gbraid: marketingAttr?.gbraid ?? null,
+        wbraid: marketingAttr?.wbraid ?? null,
+        conversion_date_time: new Date(),
+        conversion_value_chf: grossAmountRappen / 100,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+      })
+    } catch (e: any) {
+      logger.warn('⚠️ Google Ads conversion upload failed (guest):', e.message)
+    }
   }
 
   try {

--- a/server/api/booking/submit-general-inquiry.post.ts
+++ b/server/api/booking/submit-general-inquiry.post.ts
@@ -4,7 +4,7 @@
 // - Specific request: contact info + category + location + duration + preferred_time_slots
 // Contact field requirements follow tenant booking_policy.booking_required_fields
 
-import { defineEventHandler, readBody, createError, getRequestIP } from 'h3'
+import { defineEventHandler, readBody, createError, getRequestIP, getHeader } from 'h3'
 import { createClient } from '@supabase/supabase-js'
 import { v4 as uuidv4 } from 'uuid'
 import { recordAndUploadInquiryConversion, sha256Hex } from '~/server/utils/google-ads-conversion'
@@ -16,6 +16,7 @@ import { normalizePhoneNumber } from '~/server/utils/sms'
 import { escapeLikePattern } from '~/server/utils/sql-helpers'
 import { getTenantTerminology } from '~/server/utils/tenant-terminology'
 import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
+import { recordAndSendCapiEvent } from '~/server/utils/meta-capi'
 
 interface MarketingAttributionPayload {
   gclid?: string | null
@@ -545,6 +546,30 @@ export default defineEventHandler(async (event) => {
       } catch (err: any) {
         console.warn('⚠️ Server-side Google Ads inquiry conversion upload failed (non-critical):', err?.message ?? err)
       }
+    }
+
+    try {
+      const normalizedEmail = (fieldValues.email || '').toLowerCase()
+      const normalizedPhone = (fieldValues.phone || '').replace(/\s+/g, '').replace(/^00/, '+')
+      const hashedEmail = normalizedEmail ? await sha256Hex(normalizedEmail) : null
+      const hashedPhone = normalizedPhone.startsWith('+') ? await sha256Hex(normalizedPhone) : null
+
+      await recordAndSendCapiEvent({
+        appointment_id: proposal.id,
+        tenant_id,
+        event_name: 'Lead',
+        conversion_value_chf: 0,
+        conversion_date_time: new Date(),
+        fbclid: resolvedAttribution?.fbclid ?? null,
+        fbc: resolvedAttribution?.fbc ?? null,
+        fbp: resolvedAttribution?.fbp ?? null,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+        client_ip: ip,
+        user_agent: getHeader(event, 'user-agent') ?? null,
+      })
+    } catch (err: any) {
+      console.warn('⚠️ Meta CAPI Lead upload failed (non-critical):', err?.message ?? err)
     }
 
     try {

--- a/server/api/booking/submit-general-inquiry.post.ts
+++ b/server/api/booking/submit-general-inquiry.post.ts
@@ -15,7 +15,7 @@ import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { normalizePhoneNumber } from '~/server/utils/sms'
 import { escapeLikePattern } from '~/server/utils/sql-helpers'
 import { getTenantTerminology } from '~/server/utils/tenant-terminology'
-import { mergeAttributionFields } from '~/server/utils/marketing-attribution-merge'
+import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
 
 interface MarketingAttributionPayload {
   gclid?: string | null
@@ -462,31 +462,11 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Prefer client payload, always merge DB + booking_redirects so click IDs
-    // survive when only session_id was forwarded from drivingteam.ch.
-    let resolvedAttribution: MarketingAttributionPayload | null = marketing_attribution ?? null
-    if (marketing_session_id) {
-      const { data: attrRow } = await supabase
-        .from('marketing_attributions')
-        .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, fbclid, fbc, fbp')
-        .eq('session_id', marketing_session_id)
-        .maybeSingle()
-      if (attrRow) {
-        resolvedAttribution = mergeAttributionFields(attrRow, resolvedAttribution) as MarketingAttributionPayload
-      }
-      if (!resolvedAttribution?.gclid && !resolvedAttribution?.gbraid && !resolvedAttribution?.wbraid) {
-        const { data: redirectRow } = await supabase
-          .from('booking_redirects')
-          .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-          .eq('session_id', marketing_session_id)
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .maybeSingle()
-        if (redirectRow) {
-          resolvedAttribution = mergeAttributionFields(resolvedAttribution, redirectRow) as MarketingAttributionPayload
-        }
-      }
-    }
+    const resolvedAttribution = await resolveMarketingAttribution(
+      supabase,
+      marketing_session_id,
+      marketing_attribution,
+    )
 
     const resolvedUserId = await resolveInquiryUserId({
       tenantId: tenant_id,

--- a/server/api/booking/submit-proposal.post.ts
+++ b/server/api/booking/submit-proposal.post.ts
@@ -1,12 +1,13 @@
 // server/api/booking/submit-proposal.post.ts
 // Submit a booking proposal when no slots are available
 
-import { defineEventHandler, readBody, createError, getRequestIP } from 'h3'
+import { defineEventHandler, readBody, createError, getRequestIP, getHeader } from 'h3'
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { recordAndUploadInquiryConversion, sha256Hex } from '~/server/utils/google-ads-conversion'
 import { checkRateLimit } from '~/server/utils/rate-limiter'
 import { upsertMarketingLeadSafe } from '~/server/utils/upsert-marketing-lead'
 import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
+import { recordAndSendCapiEvent } from '~/server/utils/meta-capi'
 
 interface MarketingAttributionPayload {
   gclid?: string | null
@@ -303,6 +304,30 @@ export default defineEventHandler(async (event) => {
       } catch (err: any) {
         console.warn('⚠️ Server-side Google Ads inquiry conversion upload failed (non-critical):', err?.message ?? err)
       }
+    }
+
+    try {
+      const normalizedEmail = (email ?? '').trim().toLowerCase()
+      const normalizedPhone = (phone ?? '').replace(/\s+/g, '').replace(/^00/, '+')
+      const hashedEmail = normalizedEmail ? await sha256Hex(normalizedEmail) : null
+      const hashedPhone = normalizedPhone.startsWith('+') ? await sha256Hex(normalizedPhone) : null
+
+      await recordAndSendCapiEvent({
+        appointment_id: proposal.id,
+        tenant_id,
+        event_name: 'Lead',
+        conversion_value_chf: 0,
+        conversion_date_time: new Date(),
+        fbclid: resolvedAttribution?.fbclid ?? null,
+        fbc: resolvedAttribution?.fbc ?? null,
+        fbp: resolvedAttribution?.fbp ?? null,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+        client_ip: ip,
+        user_agent: getHeader(event, 'user-agent') ?? null,
+      })
+    } catch (err: any) {
+      console.warn('⚠️ Meta CAPI Lead upload failed (non-critical):', err?.message ?? err)
     }
 
     // Send emails to customer and staff

--- a/server/api/booking/submit-proposal.post.ts
+++ b/server/api/booking/submit-proposal.post.ts
@@ -6,7 +6,7 @@ import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { recordAndUploadInquiryConversion, sha256Hex } from '~/server/utils/google-ads-conversion'
 import { checkRateLimit } from '~/server/utils/rate-limiter'
 import { upsertMarketingLeadSafe } from '~/server/utils/upsert-marketing-lead'
-import { mergeAttributionFields } from '~/server/utils/marketing-attribution-merge'
+import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
 
 interface MarketingAttributionPayload {
   gclid?: string | null
@@ -227,31 +227,11 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    // Resolve UTM attribution: prefer client payload, always merge DB + booking_redirects
-    // so click IDs survive even when the client only forwarded session_id.
-    let resolvedAttribution: MarketingAttributionPayload | null = marketing_attribution ?? null
-    if (marketing_session_id) {
-      const { data: attrRow } = await supabase
-        .from('marketing_attributions')
-        .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, fbclid, fbc, fbp')
-        .eq('session_id', marketing_session_id)
-        .maybeSingle()
-      if (attrRow) {
-        resolvedAttribution = mergeAttributionFields(attrRow, resolvedAttribution) as MarketingAttributionPayload
-      }
-      if (!resolvedAttribution?.gclid && !resolvedAttribution?.gbraid && !resolvedAttribution?.wbraid) {
-        const { data: redirectRow } = await supabase
-          .from('booking_redirects')
-          .select('gclid, gbraid, wbraid, utm_source, utm_medium, utm_campaign, utm_content, utm_term')
-          .eq('session_id', marketing_session_id)
-          .order('created_at', { ascending: false })
-          .limit(1)
-          .maybeSingle()
-        if (redirectRow) {
-          resolvedAttribution = mergeAttributionFields(resolvedAttribution, redirectRow) as MarketingAttributionPayload
-        }
-      }
-    }
+    const resolvedAttribution = await resolveMarketingAttribution(
+      supabase,
+      marketing_session_id,
+      marketing_attribution,
+    )
 
     // Create the proposal via service_role – this is a server-side endpoint, input is
     // already validated above. Admin client bypasses RLS safely.

--- a/server/api/courses/enroll-cash.post.ts
+++ b/server/api/courses/enroll-cash.post.ts
@@ -20,6 +20,9 @@ import { createRateLimitMiddleware } from '~/server/middleware/rate-limiting'
 import { findExistingUserByContact } from '~/server/utils/user-matching'
 import { normalizePhoneNumber } from '~/server/utils/sms'
 import { upsertMarketingLeadSafe, categoriesFromCourse } from '~/server/utils/upsert-marketing-lead'
+import { sendCapiEvent, sha256Hex } from '~/server/utils/meta-capi'
+import { recordAndUploadCourseConversion } from '~/server/utils/google-ads-conversion'
+import { resolveMarketingAttribution } from '~/server/utils/resolve-marketing-attribution'
 
 // Rate limiting: 5 attempts per IP per minute
 const rateLimiter = createRateLimitMiddleware({
@@ -61,6 +64,7 @@ const handler = defineEventHandler(async (event) => {
       partialStartPosition,
       individualSessionNumber,  // Set when booking a single allow_individual_booking session
       marketingSessionId,   // Optional: analytics session ID from drivingteam.ch for attribution
+      marketingAttribution, // Optional: client-side gclid/UTM blob
       vehicleId,            // Optional: selected rental vehicle
       paymentMethod: requestedPaymentMethod, // Optional: 'cash_on_site' (default) or 'invoice'
     } = body
@@ -618,22 +622,23 @@ const handler = defineEventHandler(async (event) => {
       })
     }
 
+    const isPartialOrd = !!(isPartialEnrollment || course.is_partial_only)
+    const isIndivSess = isPartialOrd && typeof individualSessionNumber === 'number' && individualSessionNumber > 0
+    let effectivePrice: number
+    if (isIndivSess) {
+      const tgt = (course.course_sessions || []).find(
+        (s: any) => s.session_number === individualSessionNumber && s.allow_individual_booking
+      )
+      effectivePrice = tgt?.individual_price_rappen ?? course.price_per_participant_rappen
+    } else {
+      const partialPriceRappen: number = course.course_category?.partial_price_rappen ?? 0
+      effectivePrice = (isPartialOrd && !course.is_partial_only && partialPriceRappen > 0)
+        ? partialPriceRappen
+        : course.price_per_participant_rappen
+    }
+
     // 11. Send confirmation email
     try {
-      const isPartialOrd = !!(isPartialEnrollment || course.is_partial_only)
-      const isIndivSess = isPartialOrd && typeof individualSessionNumber === 'number' && individualSessionNumber > 0
-      let effectivePrice: number
-      if (isIndivSess) {
-        const tgt = (course.course_sessions || []).find(
-          (s: any) => s.session_number === individualSessionNumber && s.allow_individual_booking
-        )
-        effectivePrice = tgt?.individual_price_rappen ?? course.price_per_participant_rappen
-      } else {
-        const partialPriceRappen: number = course.course_category?.partial_price_rappen ?? 0
-        effectivePrice = (isPartialOrd && !course.is_partial_only && partialPriceRappen > 0)
-          ? partialPriceRappen
-          : course.price_per_participant_rappen
-      }
       await $fetch('/api/emails/send-course-enrollment-confirmation', {
         method: 'POST',
         body: {
@@ -645,6 +650,42 @@ const handler = defineEventHandler(async (event) => {
       logger.info(`📧 Confirmation email sent to ${finalEmail}`)
     } catch (error: any) {
       logger.warn('⚠️ Email send failed (non-critical):', error.message)
+    }
+
+    try {
+      const attrRow = await resolveMarketingAttribution(supabase, marketingSessionId, marketingAttribution)
+      const hashedEmail = finalEmail ? await sha256Hex(finalEmail.trim().toLowerCase()) : null
+      const normalizedPhone = (finalPhone || phone || '').replace(/\s+/g, '').replace(/^00/, '+')
+      const hashedPhone = normalizedPhone.startsWith('+') ? await sha256Hex(normalizedPhone) : null
+      const valueChf = effectivePrice / 100
+      const conversionDateTime = new Date()
+
+      await sendCapiEvent({
+        appointment_id: `course_${enrollment.id}`,
+        tenant_id: tenantId,
+        event_name: 'Purchase',
+        conversion_value_chf: valueChf,
+        conversion_date_time: conversionDateTime,
+        fbclid: attrRow?.fbclid ?? null,
+        fbc: attrRow?.fbc ?? null,
+        fbp: attrRow?.fbp ?? null,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+      })
+
+      await recordAndUploadCourseConversion({
+        registration_id: enrollment.id,
+        tenant_id: tenantId,
+        gclid: attrRow?.gclid ?? null,
+        gbraid: attrRow?.gbraid ?? null,
+        wbraid: attrRow?.wbraid ?? null,
+        conversion_value_chf: valueChf,
+        conversion_date_time: conversionDateTime,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+      })
+    } catch (err: any) {
+      logger.warn('⚠️ Meta/Google Ads conversion upload failed for cash enrollment (non-critical):', err?.message ?? err)
     }
 
     return {

--- a/server/api/courses/enroll-wallee.post.ts
+++ b/server/api/courses/enroll-wallee.post.ts
@@ -704,7 +704,7 @@ const handler = defineEventHandler(async (event) => {
         // Awaited: Vercel freezes after response; fire-and-forget was dropping uploads.
         try {
           const { resolveMarketingAttribution } = await import('~/server/utils/resolve-marketing-attribution')
-          const attrRow = await resolveMarketingAttribution(supabase, marketingSessionId)
+          const attrRow = await resolveMarketingAttribution(supabase, marketingSessionId, marketingAttribution)
 
           const hashedEmail = finalEmail ? await sha256Hex(finalEmail.trim().toLowerCase()) : null
           const normalizedPhone = (finalPhone ?? '').replace(/\s+/g, '').replace(/^00/, '+')

--- a/server/api/cron/send-marketing-report.get.ts
+++ b/server/api/cron/send-marketing-report.get.ts
@@ -172,7 +172,7 @@ async function sendReport(supabase: any, tenant: { id: string; slug: string; nam
     // GA4: last 7 days by channel
     supabase
       .from('marketing_ga4_daily')
-      .select('date, channel, sessions, conversions, bounce_rate')
+      .select('date, channel, sessions, conversions')
       .eq('tenant_id', tenant.id)
       .gte('date', weekStart)
       .lt('date', weekEnd),
@@ -332,7 +332,7 @@ async function sendReport(supabase: any, tenant: { id: string; slug: string; nam
 
   // ── 5. GA4 metrics ────────────────────────────────────────────────────────
 
-  const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Referral', 'Organic Social', 'Email', 'Affiliates']
+  const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Paid Social', 'Referral', 'Organic Social', 'Email', 'Affiliates']
   const ga4Marketing = ga4.filter(r => MARKETING_CHANNELS.includes(r.channel))
   const ga4All = ga4
 

--- a/server/api/cron/sync-marketing-ga4.ts
+++ b/server/api/cron/sync-marketing-ga4.ts
@@ -1,20 +1,18 @@
 import { BetaAnalyticsDataClient } from '@google-analytics/data'
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { getTenantIdByGa4Property } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 import { logger } from '~/utils/logger'
 import { readBody } from 'h3'
+
+export const maxDuration = 120
 
 // Fetches GA4 data (sessions, users, conversions by channel + page)
 // and upserts into marketing_ga4_daily. Runs daily at 04:00 via Vercel Cron.
 // Default: last 7 days. Backfill via body: { startDate, endDate }.
 // Paginates with offset — a single 5000-row page under-counted busy properties.
 export default defineEventHandler(async (event) => {
-  // ============ LAYER 1: CRON AUTH ============
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   // ============ LAYER 2: ENV CHECK ============
   const clientEmail = process.env.GOOGLE_SA_CLIENT_EMAIL

--- a/server/api/cron/sync-marketing-google-ads-keywords.ts
+++ b/server/api/cron/sync-marketing-google-ads-keywords.ts
@@ -1,15 +1,12 @@
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { getTenantIdByGoogleAdsCustomer } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 import { logger } from '~/utils/logger'
 
 // Fetches keyword-level Google Ads performance (last 7 days) and upserts into
 // marketing_google_ads_keywords_daily. Runs daily at 04:30 via Vercel Cron.
 export default defineEventHandler(async (event) => {
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   const developerToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN
   const clientId = process.env.GOOGLE_ADS_CLIENT_ID

--- a/server/api/cron/sync-marketing-google-ads-search-terms.ts
+++ b/server/api/cron/sync-marketing-google-ads-search-terms.ts
@@ -1,5 +1,6 @@
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { getTenantIdByGoogleAdsCustomer } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 import { logger } from '~/utils/logger'
 
 // Fetches the last 7 days of Google Ads search terms (actual queries that triggered ads)
@@ -7,12 +8,7 @@ import { logger } from '~/utils/logger'
 // Runs daily at 04:50 via Vercel Cron.
 // Key use case: identify wasted spend from irrelevant search terms → negative keywords.
 export default defineEventHandler(async (event) => {
-  // ============ LAYER 1: CRON AUTH ============
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   // ============ LAYER 2: ENV CHECK ============
   const developerToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN

--- a/server/api/cron/sync-marketing-google-ads.ts
+++ b/server/api/cron/sync-marketing-google-ads.ts
@@ -1,16 +1,12 @@
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { getTenantIdByGoogleAdsCustomer } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 import { logger } from '~/utils/logger'
 
 // Fetches the last 7 days of Google Ads campaign performance via REST API
 // and upserts into marketing_google_ads_daily. Runs daily at 04:10 via Vercel Cron.
 export default defineEventHandler(async (event) => {
-  // ============ LAYER 1: CRON AUTH ============
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   // ============ LAYER 2: ENV CHECK ============
   const developerToken = process.env.GOOGLE_ADS_DEVELOPER_TOKEN

--- a/server/api/cron/sync-marketing-gsc.ts
+++ b/server/api/cron/sync-marketing-gsc.ts
@@ -1,7 +1,10 @@
 import { google } from 'googleapis'
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { getTenantIdByGscSite } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 import { logger } from '~/utils/logger'
+
+export const maxDuration = 120
 
 // Fetches Search Console data and upserts into marketing_gsc_daily.
 // Runs daily at 04:00 via Vercel Cron (last 5 days).
@@ -13,12 +16,7 @@ import { logger } from '~/utils/logger'
 //   1) use 7-day chunks (not 30)
 //   2) paginate with startRow up to GSC max rowLimit (25000)
 export default defineEventHandler(async (event) => {
-  // ============ LAYER 1: CRON AUTH ============
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   // ============ LAYER 2: ENV CHECK ============
   const clientId = process.env.GOOGLE_OAUTH_CLIENT_ID

--- a/server/api/cron/sync-marketing-meta-ads.ts
+++ b/server/api/cron/sync-marketing-meta-ads.ts
@@ -1,6 +1,7 @@
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { logger } from '~/utils/logger'
 import { getTenantIdByMetaAdAccount } from '~/server/utils/marketing-tenant'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 
 /**
  * Daily Meta Ads sync — runs at 04:20 via Vercel Cron.
@@ -14,12 +15,7 @@ import { getTenantIdByMetaAdAccount } from '~/server/utils/marketing-tenant'
  * Register ad accounts: INSERT INTO marketing_meta_accounts (tenant_id, ad_account_id, pixel_id, label)
  */
 export default defineEventHandler(async (event) => {
-  // ============ LAYER 1: CRON AUTH ============
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   // ============ LAYER 2: ENV CHECK ============
   const accessToken = process.env.META_SYSTEM_USER_TOKEN ?? process.env.META_ACCESS_TOKEN

--- a/server/api/cron/weekly-marketing-review.ts
+++ b/server/api/cron/weekly-marketing-review.ts
@@ -2,16 +2,38 @@ import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { logger } from '~/utils/logger'
 import { assertCronRequest } from '~/server/utils/cron-auth'
 
+function getMonday(d: Date): Date {
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1)
+  const mon = new Date(d)
+  mon.setDate(diff)
+  mon.setHours(0, 0, 0, 0)
+  return mon
+}
+
+function addWeeks(d: Date, weeks: number): Date {
+  const r = new Date(d)
+  r.setDate(r.getDate() + weeks * 7)
+  return r
+}
+
+function dateStr(d: Date): string {
+  return d.toISOString().split('T')[0]
+}
+
 // Runs every Monday at 07:00 via Vercel Cron.
-// Analyzes the past 7 days of GA4, GSC, Google Ads data and generates
-// a prioritized Top-5 action list + low-hanging fruits per tenant.
+// Same completed ISO week as send-marketing-report (Mon–Sun, exclusive end).
 export default defineEventHandler(async (event) => {
   assertCronRequest(event)
 
   const supabase = getSupabaseAdmin()
-  const since = new Date()
-  since.setDate(since.getDate() - 7)
-  const sinceStr = since.toISOString().split('T')[0]
+  const now = new Date()
+  const thisMonday = getMonday(now)
+  const lastMonday = addWeeks(thisMonday, -1)
+  const weekStart = dateStr(lastMonday)
+  const weekEnd = dateStr(thisMonday)
+  const weekNumber = getISOWeek(lastMonday)
+  const year = lastMonday.getFullYear()
 
   // Get all tenants with marketing credentials
   const { data: tenants } = await supabase
@@ -25,7 +47,7 @@ export default defineEventHandler(async (event) => {
 
   for (const tenant of tenants) {
     try {
-      const review = await generateReview(supabase, tenant.id, sinceStr)
+      const review = await generateReview(supabase, tenant.id, weekStart, weekEnd, weekNumber, year)
       results.push({ tenant: tenant.slug, ...review })
     } catch (err: any) {
       logger.error(`weekly-review: failed for ${tenant.slug}: ${err.message}`)
@@ -36,50 +58,62 @@ export default defineEventHandler(async (event) => {
   return { success: true, results }
 })
 
-async function generateReview(supabase: any, tenantId: string, since: string) {
-  const now = new Date()
-  const weekNumber = getISOWeek(now)
-  const year = now.getFullYear()
-
+async function generateReview(
+  supabase: any,
+  tenantId: string,
+  weekStart: string,
+  weekEnd: string,
+  weekNumber: number,
+  year: number,
+) {
   // ── Fetch data in parallel ──────────────────────────────────────────────
-  const [ga4Res, gscOppRes, gscCtrRes, adsRes, metaRes] = await Promise.all([
-    // GA4: sessions + conversions by channel last 7 days
+  const [ga4Res, gscOppRes, gscCtrRes, adsRes, metaRes, apptsRes] = await Promise.all([
     supabase
       .from('marketing_ga4_daily')
       .select('date, channel, sessions, conversions')
       .eq('tenant_id', tenantId)
-      .gte('date', since),
+      .gte('date', weekStart)
+      .lt('date', weekEnd),
 
-    // GSC: keywords on position 4-15 (SEO opportunities)
     supabase
       .from('marketing_gsc_daily')
       .select('query, page, clicks, impressions, position')
       .eq('tenant_id', tenantId)
-      .gte('date', since)
+      .gte('date', weekStart)
+      .lt('date', weekEnd)
       .gte('position', 4)
       .lte('position', 15),
 
-    // GSC: position < 5 but low clicks (CTR bugs)
     supabase
       .from('marketing_gsc_daily')
       .select('query, page, clicks, impressions, position')
       .eq('tenant_id', tenantId)
-      .gte('date', since)
+      .gte('date', weekStart)
+      .lt('date', weekEnd)
       .lt('position', 5),
 
-    // Google Ads
     supabase
       .from('marketing_google_ads_daily')
       .select('campaign_name, cost_micros, clicks, impressions, conversions')
       .eq('tenant_id', tenantId)
-      .gte('date', since),
+      .gte('date', weekStart)
+      .lt('date', weekEnd),
 
-    // Meta Ads
     supabase
       .from('marketing_meta_ads_daily')
       .select('campaign_name, spend, clicks, impressions, reach, actions')
       .eq('tenant_id', tenantId)
-      .gte('date', since),
+      .gte('date', weekStart)
+      .lt('date', weekEnd),
+
+    supabase
+      .from('appointments')
+      .select('gclid, gbraid, wbraid, fbclid')
+      .eq('tenant_id', tenantId)
+      .gte('created_at', weekStart)
+      .lt('created_at', weekEnd)
+      .is('deleted_at', null)
+      .neq('status', 'cancelled'),
   ])
 
   const ga4 = ga4Res.data ?? []
@@ -87,11 +121,12 @@ async function generateReview(supabase: any, tenantId: string, since: string) {
   const gscCtr = gscCtrRes.data ?? []
   const ads = adsRes.data ?? []
   const metaAds = metaRes.data ?? []
+  const appointments = apptsRes.data ?? []
 
   // ── Compute metrics ──────────────────────────────────────────────────────
   // Only count known marketing channels — exclude "Unassigned" (existing students via app)
   // and "Direct" (ambiguous: mix of new visitors and existing students typing URL directly)
-  const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Referral', 'Organic Social', 'Email', 'Affiliates']
+  const MARKETING_CHANNELS = ['Organic Search', 'Paid Search', 'Paid Social', 'Referral', 'Organic Social', 'Email', 'Affiliates']
   const marketingGa4 = ga4.filter((r: any) => MARKETING_CHANNELS.includes(r.channel))
 
   const totalSessions = marketingGa4.reduce((s: number, r: any) => s + (r.sessions ?? 0), 0)
@@ -124,10 +159,14 @@ async function generateReview(supabase: any, tenantId: string, since: string) {
     return s + (purchases ? Number(purchases.value ?? 0) : 0)
   }, 0)
   const metaCpc = metaClicks > 0 ? (metaSpendCHF / metaClicks).toFixed(2) : null
-  const metaCpa = metaConversions > 0 ? (metaSpendCHF / metaConversions).toFixed(0) : null
-  const googleCpa = ads.reduce((s: number, r: any) => s + (r.conversions ?? 0), 0) > 0
-    ? (totalSpendCHF / ads.reduce((s: number, r: any) => s + (r.conversions ?? 0), 0)).toFixed(0)
-    : null
+
+  // First-party CPA: bookings with a click ID on the appointment, same week as spend.
+  // Platform pixels (Google Ads conversions / Meta purchase) use different windows
+  // and overcount — never use those for budget-shift tips.
+  const googleFpConversions = appointments.filter((a: any) => a.gclid || a.gbraid || a.wbraid).length
+  const metaFpConversions = appointments.filter((a: any) => a.fbclid).length
+  const googleCpa = googleFpConversions > 0 ? (totalSpendCHF / googleFpConversions).toFixed(0) : null
+  const metaCpa = metaFpConversions > 0 ? (metaSpendCHF / metaFpConversions).toFixed(0) : null
 
   // SEO opportunities (aggregate by query, position 4-15)
   const oppMap = new Map<string, { impressions: number; clicks: number; positions: number[] }>()
@@ -189,19 +228,21 @@ async function generateReview(supabase: any, tenantId: string, since: string) {
     fruits.push(`CPC diese Woche: CHF ${cpc} – negative Keywords hinzufügen um Budget effizienter einzusetzen.`)
   }
 
-  // Meta Ads recommendations
+  // Meta Ads recommendations — only compare CPA when both sides have first-party bookings
   if (metaSpendCHF > 0) {
-    if (metaCpa && googleCpa) {
+    if (googleFpConversions === 0 || metaFpConversions === 0) {
+      fruits.push(`Kein Budget-Shift: ${googleFpConversions} Google- und ${metaFpConversions} Meta-Buchungen mit Click-ID. Erst Attribution prüfen, dann Kanäle vergleichen.`)
+    } else if (metaCpa && googleCpa) {
       const metaCpaNum = parseFloat(metaCpa)
       const googleCpaNum = parseFloat(googleCpa)
       if (metaCpaNum < googleCpaNum * 0.8) {
-        actions.push(`Meta Ads effizienter als Google: CPA CHF ${metaCpa} vs. Google CHF ${googleCpa} – Budget von Google zu Meta verschieben (CHF ${Math.round(totalSpendCHF * 0.2)}/Woche).`)
+        actions.push(`Meta Ads effizienter als Google: CPA CHF ${metaCpa} vs. Google CHF ${googleCpa} (${metaFpConversions} vs. ${googleFpConversions} First-Party-Buchungen) – Budget von Google zu Meta verschieben (CHF ${Math.round(totalSpendCHF * 0.2)}/Woche).`)
       } else if (metaCpaNum > googleCpaNum * 1.5) {
         fruits.push(`Meta CPA (CHF ${metaCpa}) deutlich höher als Google (CHF ${googleCpa}) – Meta Zielgruppen verfeinern oder Budget zu Google verschieben.`)
       }
     }
-    if (metaClicks > 0 && metaConversions === 0) {
-      actions.push(`Meta Ads: ${metaClicks} Klicks diese Woche aber 0 CAPI-Conversions – CAPI-Integration prüfen und Test-Event im Meta Events Manager triggern.`)
+    if (metaClicks > 0 && metaFpConversions === 0) {
+      actions.push(`Meta Ads: ${metaClicks} Klicks diese Woche aber 0 First-Party-Buchungen mit fbclid – Click-ID-Handoff prüfen (drivingteam.ch → app.simy.ch).`)
     }
     if (metaCpc && parseFloat(metaCpc) > 1.5) {
       fruits.push(`Meta CPC: CHF ${metaCpc} – Audience-Targeting einengen oder ähnliche Zielgruppen (Lookalike) auf Basis der bestehenden Kundenliste testen.`)
@@ -223,9 +264,9 @@ async function generateReview(supabase: any, tenantId: string, since: string) {
 
   // Summary
   const metaSummaryPart = metaSpendCHF > 0
-    ? ` Meta: CHF ${metaSpendCHF.toFixed(0)} Spend, ${metaClicks} Klicks, ${metaConversions} Conversions${metaCpa ? ` (CPA CHF ${metaCpa})` : ''}.`
+    ? ` Meta: CHF ${metaSpendCHF.toFixed(0)} Spend, ${metaClicks} Klicks, ${metaFpConversions} First-Party-Buchungen${metaCpa ? ` (CPA CHF ${metaCpa})` : ''}.`
     : ''
-  const summary = `Diese Woche: ${totalSessions} Marketing-Sessions (ohne Unassigned/Direct), ${totalConversions} Conversions (CVR ${cvr}%), CHF ${totalSpendCHF.toFixed(0)} Google Ads Spend.${metaSummaryPart} ${topOpps.length} SEO-Chancen in Position 4–15 identifiziert.`
+  const summary = `Diese Woche: ${totalSessions} Marketing-Sessions (ohne Unassigned/Direct), ${totalConversions} GA4-Conversions (CVR ${cvr}%), CHF ${totalSpendCHF.toFixed(0)} Google Ads Spend, ${googleFpConversions} First-Party-Buchungen mit gclid.${metaSummaryPart} ${topOpps.length} SEO-Chancen in Position 4–15 identifiziert.`
 
   // ── Save to DB ────────────────────────────────────────────────────────────
   const { error } = await supabase
@@ -243,6 +284,7 @@ async function generateReview(supabase: any, tenantId: string, since: string) {
           googleSpendCHF: Math.round(totalSpendCHF * 100) / 100,
           metaSpendCHF: Math.round(metaSpendCHF * 100) / 100,
           metaClicks, metaConversions,
+          googleFpConversions, metaFpConversions,
           metaCpa: metaCpa ? parseFloat(metaCpa) : null,
           googleCpa: googleCpa ? parseFloat(googleCpa) : null,
         },

--- a/server/api/cron/weekly-marketing-review.ts
+++ b/server/api/cron/weekly-marketing-review.ts
@@ -1,15 +1,12 @@
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 import { logger } from '~/utils/logger'
+import { assertCronRequest } from '~/server/utils/cron-auth'
 
 // Runs every Monday at 07:00 via Vercel Cron.
 // Analyzes the past 7 days of GA4, GSC, Google Ads data and generates
 // a prioritized Top-5 action list + low-hanging fruits per tenant.
 export default defineEventHandler(async (event) => {
-  const authHeader = getHeader(event, 'authorization')
-  const cronSecret = process.env.CRON_SECRET
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
-  }
+  assertCronRequest(event)
 
   const supabase = getSupabaseAdmin()
   const since = new Date()

--- a/server/utils/cron-auth.ts
+++ b/server/utils/cron-auth.ts
@@ -1,0 +1,12 @@
+import { createError, getHeader, type H3Event } from 'h3'
+
+/** Vercel Cron is GET and sends x-vercel-cron: 1 plus Bearer CRON_SECRET when that env is set. */
+export function assertCronRequest(event: H3Event) {
+  const isVercelCron = getHeader(event, 'x-vercel-cron') === '1'
+  const cronSecret = process.env.CRON_SECRET
+  const authHeader = getHeader(event, 'authorization')
+  const isValidSecret = !!(cronSecret?.trim() && authHeader === `Bearer ${cronSecret}`)
+  if (!isVercelCron && !isValidSecret) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+}

--- a/server/utils/marketing-attribution-merge.ts
+++ b/server/utils/marketing-attribution-merge.ts
@@ -57,6 +57,11 @@ export function hasClickId(attr: AttributionFields | null | undefined): boolean 
   return !!(attr?.gclid || attr?.gbraid || attr?.wbraid)
 }
 
+/** Google or Meta click ID — used to decide whether a booking is paid-attributed. */
+export function hasPaidClickId(attr: AttributionFields | null | undefined): boolean {
+  return !!(attr?.gclid || attr?.gbraid || attr?.wbraid || attr?.fbclid)
+}
+
 export function hasAnyAttribution(attr: AttributionFields | null | undefined): boolean {
   if (!attr) return false
   return !!(

--- a/server/utils/proposal-booking-conversion.ts
+++ b/server/utils/proposal-booking-conversion.ts
@@ -19,6 +19,7 @@ import {
 } from '~/server/utils/google-ads-conversion'
 import { normalizePhoneNumber } from '~/server/utils/sms'
 import { logger } from '~/utils/logger'
+import { recordAndSendCapiEvent } from '~/server/utils/meta-capi'
 
 const PROPOSAL_LOOKBACK_DAYS = 90
 export const proposalBookingOrderId = (proposalId: string) => `proposal-booking-${proposalId}`
@@ -47,8 +48,12 @@ export type ProposalAttributionRow = {
   created_at: string
 }
 
-function hasClickId(row: { gclid?: string | null; gbraid?: string | null; wbraid?: string | null }): boolean {
+function hasGoogleClickId(row: { gclid?: string | null; gbraid?: string | null; wbraid?: string | null }): boolean {
   return !!(row.gclid || row.gbraid || row.wbraid)
+}
+
+function hasMetaClickId(row: { fbclid?: string | null; fbc?: string | null; fbp?: string | null }): boolean {
+  return !!(row.fbclid || row.fbc || row.fbp)
 }
 
 function phonesMatch(a: string | null | undefined, b: string | null | undefined): boolean {
@@ -88,7 +93,7 @@ export async function findAttributedProposalForCustomer(
     .eq('tenant_id', params.tenantId)
     .gte('created_at', since)
     .not('status', 'eq', 'rejected')
-    .or('gclid.not.is.null,gbraid.not.is.null,wbraid.not.is.null')
+    .or('gclid.not.is.null,gbraid.not.is.null,wbraid.not.is.null,fbclid.not.is.null')
     .order('created_at', { ascending: false })
     .limit(40)
 
@@ -108,7 +113,7 @@ export async function findAttributedProposalForCustomer(
     return false
   })
 
-  return matched && hasClickId(matched) ? matched : null
+  return matched && (hasGoogleClickId(matched) || hasMetaClickId(matched)) ? matched : null
 }
 
 async function alreadyUploadedProposalBooking(proposalId: string): Promise<boolean> {
@@ -131,16 +136,17 @@ async function alreadyUploadedProposalBooking(proposalId: string): Promise<boole
 export async function uploadProposalDerivedBookingConversion(input: {
   proposal: Pick<
     ProposalAttributionRow,
-    'id' | 'tenant_id' | 'gclid' | 'gbraid' | 'wbraid' | 'email' | 'phone'
+    'id' | 'tenant_id' | 'gclid' | 'gbraid' | 'wbraid' | 'fbclid' | 'fbc' | 'fbp' | 'email' | 'phone'
   >
   appointmentId?: string | null
   conversionValueChf?: number | null
 }): Promise<'uploaded' | 'skipped_already' | 'skipped_no_click_id' | 'failed'> {
-  if (!hasClickId(input.proposal)) return 'skipped_no_click_id'
+  const google = hasGoogleClickId(input.proposal)
+  const meta = hasMetaClickId(input.proposal)
+  if (!google && !meta) return 'skipped_no_click_id'
 
-  if (await alreadyUploadedProposalBooking(input.proposal.id)) {
-    return 'skipped_already'
-  }
+  const alreadyGoogle = await alreadyUploadedProposalBooking(input.proposal.id)
+  if (alreadyGoogle && !meta) return 'skipped_already'
 
   const value = normalizeConversionValueChf(
     input.conversionValueChf && input.conversionValueChf > 0
@@ -153,82 +159,111 @@ export async function uploadProposalDerivedBookingConversion(input: {
   const hashedEmail = email ? await sha256Hex(email) : null
   const hashedPhone = phoneRaw.startsWith('+') ? await sha256Hex(phoneRaw) : null
 
-  const supabase = getSupabaseAdmin()
-  const orderId = proposalBookingOrderId(input.proposal.id)
-  const conversionActionId = (process.env.GOOGLE_ADS_CONVERSION_ACTION_ID || '').trim() || 'unknown'
+  let googleResult: 'uploaded' | 'skipped_already' | 'failed' | null = alreadyGoogle ? 'skipped_already' : null
 
-  // Audit row first (appointment_id optional — FK only when real appointment exists).
-  const { data: row, error: insertError } = await supabase
-    .from('google_ads_conversion_uploads')
-    .insert({
-      appointment_id: input.appointmentId || null,
-      proposal_id: input.proposal.id,
-      order_id: orderId,
-      tenant_id: input.proposal.tenant_id,
-      conversion_action_id: conversionActionId,
-      gclid: input.proposal.gclid,
-      gbraid: input.proposal.gbraid,
-      wbraid: input.proposal.wbraid,
-      conversion_value_chf: value,
-      conversion_date_time: new Date().toISOString(),
-      upload_status: 'pending',
-      upload_attempts: 0,
-    })
-    .select('id')
-    .single()
+  if (google && !alreadyGoogle) {
+    const supabase = getSupabaseAdmin()
+    const orderId = proposalBookingOrderId(input.proposal.id)
+    const conversionActionId = (process.env.GOOGLE_ADS_CONVERSION_ACTION_ID || '').trim() || 'unknown'
 
-  if (insertError) {
-    // Unique race / duplicate: treat as already handled.
-    if (await alreadyUploadedProposalBooking(input.proposal.id)) {
-      return 'skipped_already'
+    const { data: row, error: insertError } = await supabase
+      .from('google_ads_conversion_uploads')
+      .insert({
+        appointment_id: input.appointmentId || null,
+        proposal_id: input.proposal.id,
+        order_id: orderId,
+        tenant_id: input.proposal.tenant_id,
+        conversion_action_id: conversionActionId,
+        gclid: input.proposal.gclid,
+        gbraid: input.proposal.gbraid,
+        wbraid: input.proposal.wbraid,
+        conversion_value_chf: value,
+        conversion_date_time: new Date().toISOString(),
+        upload_status: 'pending',
+        upload_attempts: 0,
+      })
+      .select('id')
+      .single()
+
+    if (insertError) {
+      if (await alreadyUploadedProposalBooking(input.proposal.id)) {
+        googleResult = 'skipped_already'
+      } else {
+        logger.warn('proposal-booking-conversion: audit insert failed', insertError.message)
+      }
     }
-    logger.warn('proposal-booking-conversion: audit insert failed', insertError.message)
-  }
 
-  try {
-    const result = await uploadClickConversion({
-      appointment_id: input.appointmentId || undefined,
-      order_id: orderId,
-      conversion_action_id: conversionActionId === 'unknown' ? undefined : conversionActionId,
-      gclid: input.proposal.gclid,
-      gbraid: input.proposal.gbraid,
-      wbraid: input.proposal.wbraid,
-      conversion_value_chf: value,
-      conversion_date_time: new Date(),
-      hashed_email: hashedEmail,
-      hashed_phone: hashedPhone,
-    })
-
-    if (row?.id) {
-      await supabase
-        .from('google_ads_conversion_uploads')
-        .update({
-          upload_status: result.uploaded
-            ? 'success'
-            : result.reason === 'no_click_id'
-              ? 'skipped_no_click_id'
-              : 'failed',
-          upload_attempts: 1,
-          last_attempt_at: new Date().toISOString(),
-          error_message: result.error || result.reason || null,
-          google_response: result.google_response ?? null,
+    if (googleResult !== 'skipped_already') {
+      try {
+        const result = await uploadClickConversion({
+          appointment_id: input.appointmentId || undefined,
+          order_id: orderId,
+          conversion_action_id: conversionActionId === 'unknown' ? undefined : conversionActionId,
+          gclid: input.proposal.gclid,
+          gbraid: input.proposal.gbraid,
+          wbraid: input.proposal.wbraid,
+          conversion_value_chf: value,
+          conversion_date_time: new Date(),
+          hashed_email: hashedEmail,
+          hashed_phone: hashedPhone,
         })
-        .eq('id', row.id)
-    }
 
-    if (result.uploaded) {
-      logger.info(`proposal-booking-conversion: uploaded booking for proposal ${input.proposal.id} (CHF ${value})`)
-      return 'uploaded'
-    }
+        if (row?.id) {
+          await supabase
+            .from('google_ads_conversion_uploads')
+            .update({
+              upload_status: result.uploaded
+                ? 'success'
+                : result.reason === 'no_click_id'
+                  ? 'skipped_no_click_id'
+                  : 'failed',
+              upload_attempts: 1,
+              last_attempt_at: new Date().toISOString(),
+              error_message: result.error || result.reason || null,
+              google_response: result.google_response ?? null,
+            })
+            .eq('id', row.id)
+        }
 
-    logger.warn(
-      `proposal-booking-conversion: upload failed for proposal ${input.proposal.id} — ${result.reason}${result.error ? `: ${result.error.slice(0, 160)}` : ''}`,
-    )
-    return 'failed'
-  } catch (err: any) {
-    logger.warn('proposal-booking-conversion: exception', err?.message ?? err)
-    return 'failed'
+        if (result.uploaded) {
+          logger.info(`proposal-booking-conversion: uploaded booking for proposal ${input.proposal.id} (CHF ${value})`)
+          googleResult = 'uploaded'
+        } else {
+          logger.warn(
+            `proposal-booking-conversion: upload failed for proposal ${input.proposal.id} — ${result.reason}${result.error ? `: ${result.error.slice(0, 160)}` : ''}`,
+          )
+          googleResult = 'failed'
+        }
+      } catch (err: any) {
+        logger.warn('proposal-booking-conversion: exception', err?.message ?? err)
+        googleResult = 'failed'
+      }
+    }
   }
+
+  if (meta) {
+    try {
+      await recordAndSendCapiEvent({
+        appointment_id: input.appointmentId || `proposal_${input.proposal.id}`,
+        tenant_id: input.proposal.tenant_id,
+        event_name: 'Purchase',
+        conversion_value_chf: value,
+        conversion_date_time: new Date(),
+        fbclid: input.proposal.fbclid ?? null,
+        fbc: input.proposal.fbc ?? null,
+        fbp: input.proposal.fbp ?? null,
+        hashed_email: hashedEmail,
+        hashed_phone: hashedPhone,
+      })
+    } catch (err: any) {
+      logger.warn('proposal-booking-conversion: Meta CAPI failed', err?.message ?? err)
+    }
+  }
+
+  if (googleResult === 'uploaded' || meta) return 'uploaded'
+  if (googleResult === 'skipped_already') return 'skipped_already'
+  if (googleResult === 'failed') return 'failed'
+  return 'uploaded'
 }
 
 /**
@@ -239,31 +274,37 @@ export async function stampAppointmentFromProposal(
   appointmentId: string,
   proposal: ProposalAttributionRow,
 ): Promise<void> {
-  if (!hasClickId(proposal)) return
+  if (!hasGoogleClickId(proposal) && !hasMetaClickId(proposal)) return
 
   const { data: appt } = await supabase
     .from('appointments')
-    .select('id, gclid, gbraid, wbraid')
+    .select('id, gclid, gbraid, wbraid, fbclid')
     .eq('id', appointmentId)
     .maybeSingle()
 
   if (!appt) return
-  if (appt.gclid || appt.gbraid || appt.wbraid) return
+  const needsGoogle = !(appt.gclid || appt.gbraid || appt.wbraid) && hasGoogleClickId(proposal)
+  const needsMeta = !appt.fbclid && hasMetaClickId(proposal)
+  if (!needsGoogle && !needsMeta) return
 
   const { error } = await supabase
     .from('appointments')
     .update({
-      gclid: proposal.gclid,
-      gbraid: proposal.gbraid,
-      wbraid: proposal.wbraid,
+      ...(needsGoogle ? {
+        gclid: proposal.gclid,
+        gbraid: proposal.gbraid,
+        wbraid: proposal.wbraid,
+      } : {}),
       utm_source: proposal.utm_source,
       utm_medium: proposal.utm_medium,
       utm_campaign: proposal.utm_campaign,
       utm_content: proposal.utm_content,
       utm_term: proposal.utm_term,
-      fbclid: proposal.fbclid,
-      fbc: proposal.fbc,
-      fbp: proposal.fbp,
+      ...(needsMeta ? {
+        fbclid: proposal.fbclid,
+        fbc: proposal.fbc,
+        fbp: proposal.fbp,
+      } : {}),
       marketing_session_id: proposal.marketing_session_id,
     })
     .eq('id', appointmentId)


### PR DESCRIPTION
## Summary
- Vercel GET crons can fill GSC/GA4/Ads/Meta sync tables (they were POST-only and returned 405).
- Weekly report no longer queries the missing `bounce_rate` column, so GA4 sessions/CVR stop showing as 0.
- Booking links now pass `gclid`/`fbclid` as URL params; booking endpoints use `resolveMarketingAttribution`. CPA tips use first-party click IDs on the same ISO week and do not recommend a budget shift when attributed bookings are 0.

## Test plan
- [ ] After deploy, Vercel nightly GET crons write rows into `marketing_*_daily` (no 405).
- [ ] Incognito: `https://drivingteam.ch/?gclid=TEST_GCLID_001&utm_source=google&utm_medium=cpc` → Buchen URL has `session_id`, `dt_attr`, and `gclid`.
- [ ] After a real booking from that path, `appointments.gclid` is set.
- [ ] Resend or wait for Monday report: GA4 CVR is not 0 when sessions exist; no «Budget zu Meta» tip if first-party Meta/Google bookings are 0.


Made with [Cursor](https://cursor.com)