### PR TITLE
feat(simy): short link redirect for SMS/print campaigns

### DIFF
--- a/apps/simy/server/routes/fl.get.ts
+++ b/apps/simy/server/routes/fl.get.ts
@@ -1,0 +1,28 @@
+/**
+ * Short-link redirect for SMS/print campaigns aimed at driving-instructor
+ * prospects: keeps the link in the message short and human-readable
+ * ("simy.ch/fl") while still attaching full UTM attribution server-side
+ * before redirecting to the actual landing page, so GA4 can attribute the
+ * session correctly.
+ *
+ * Usage in a message: simy.ch/fl (defaults to campaign "fahrlehrer-empfehlung")
+ * Optional override for a different drop: simy.ch/fl?c=other-campaign-name
+ */
+import { defineEventHandler, getQuery, sendRedirect } from 'h3'
+
+const DEFAULT_CAMPAIGN = 'fahrlehrer-empfehlung'
+const TARGET_PATH = '/fahrschule'
+
+export default defineEventHandler((event) => {
+  const query = getQuery(event)
+  const raw = typeof query.c === 'string' ? query.c.trim() : ''
+  const campaign = raw ? raw.slice(0, 60) : DEFAULT_CAMPAIGN
+
+  const params = new URLSearchParams({
+    utm_source: 'sms',
+    utm_medium: 'sms',
+    utm_campaign: campaign,
+  })
+
+  return sendRedirect(event, `${TARGET_PATH}?${params.toString()}`, 302)
+})

--- a/apps/simy/vercel.json
+++ b/apps/simy/vercel.json
@@ -1,7 +1,7 @@
 {
   "redirects": [
     {
-      "source": "/((?!_nuxt/|_payload|api/|fahrschule|marketing|branchen|vergleich|coaching|consulting|personal-training|nachhilfe|musikschule|hundeschule|massage|preise|demo|kunden|kontakt|impressum|agb|datenschutz|konto-loeschen|features|ueber-uns|partner|website|sitemap|robots\\.txt|screenshots/|devices/|.*\\.(?:png|jpe?g|webp|gif|svg|ico|woff2?|ttf|css|js|map|xml|txt|pdf|json|webmanifest)$).+)",
+      "source": "/((?!_nuxt/|_payload|api/|fahrschule|marketing|branchen|vergleich|coaching|consulting|personal-training|nachhilfe|musikschule|hundeschule|massage|preise|demo|kunden|kontakt|impressum|agb|datenschutz|konto-loeschen|features|ueber-uns|partner|website|sitemap|robots\\.txt|screenshots/|devices/|fl|.*\\.(?:png|jpe?g|webp|gif|svg|ico|woff2?|ttf|css|js|map|xml|txt|pdf|json|webmanifest)$).+)",
       "destination": "https://app.simy.ch/$1",
       "permanent": false
     }


### PR DESCRIPTION
## Summary
- Adds `apps/simy/server/routes/fl.get.ts`: `simy.ch/fl` 302-redirects to `simy.ch/fahrschule?utm_source=sms&utm_medium=sms&utm_campaign=...` so outbound SMS/print links can stay short while GA4 still gets full UTM attribution server-side. Campaign name is overridable via `?c=` for future drops.
- Updates `apps/simy/vercel.json` to exclude `/fl` from the generic app.simy.ch forwarding redirect, so it's served by the marketing site instead.

Context: needed for an outbound SMS campaign recommending Simy to ~315 driving-instructor leads that have no email on file.

## Test plan
- [x] Built production bundle (`node-server` preset) locally and verified `GET /fl` returns `302` to `/fahrschule?utm_source=sms&utm_medium=sms&utm_campaign=fahrlehrer-empfehlung`, and `/fl?c=x` overrides the campaign param.
- [x] Followed the redirect end-to-end locally (`200` on `/fahrschule`).
- [x] Root pre-push smoke test passed (build boots, `/api/health` returns 200).
- [ ] After deploy: confirm `https://simy.ch/fl` redirects correctly in production and GA4 shows the `sms` medium session.

Made with [Cursor](https://cursor.com)