### PR TITLE
feat(simy): log SMS short-link clicks to Supabase

### DIFF
--- a/apps/simy/server/routes/fl.get.ts
+++ b/apps/simy/server/routes/fl.get.ts
@@ -7,11 +7,44 @@
  *
  * Usage in a message: simy.ch/fl (defaults to campaign "fahrlehrer-empfehlung")
  * Optional override for a different drop: simy.ch/fl?c=other-campaign-name
+ *
+ * Also logs each click to Supabase (public.sms_link_clicks via the
+ * log_sms_link_click RPC) so click counts can be checked directly in the
+ * database — no GA4 property access needed for this specific campaign.
+ * The RPC only allows inserting into that one table (security definer,
+ * narrow grant to anon), so the publishable key used here can't do anything
+ * else. Logging failures never block the redirect.
  */
-import { defineEventHandler, getQuery, sendRedirect } from 'h3'
+import { defineEventHandler, getHeader, getQuery, sendRedirect, type H3Event } from 'h3'
 
 const DEFAULT_CAMPAIGN = 'fahrlehrer-empfehlung'
 const TARGET_PATH = '/fahrschule'
+
+function logClickInBackground(campaign: string, targetPath: string, event: H3Event) {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const supabaseKey = process.env.SUPABASE_ANON_KEY
+  if (!supabaseUrl || !supabaseKey) return
+
+  const userAgent = getHeader(event, 'user-agent') ?? null
+  const referrer = getHeader(event, 'referer') ?? null
+
+  fetch(`${supabaseUrl}/rest/v1/rpc/log_sms_link_click`, {
+    method: 'POST',
+    headers: {
+      apikey: supabaseKey,
+      Authorization: `Bearer ${supabaseKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      p_campaign: campaign,
+      p_target_path: targetPath,
+      p_user_agent: userAgent,
+      p_referrer: referrer,
+    }),
+  }).catch(() => {
+    // Never block the redirect on logging failures.
+  })
+}
 
 export default defineEventHandler((event) => {
   const query = getQuery(event)
@@ -23,6 +56,8 @@ export default defineEventHandler((event) => {
     utm_medium: 'sms',
     utm_campaign: campaign,
   })
+
+  logClickInBackground(campaign, TARGET_PATH, event)
 
   return sendRedirect(event, `${TARGET_PATH}?${params.toString()}`, 302)
 })


### PR DESCRIPTION
## Summary
- The GA4 analytics-sync service account only has viewer access to the drivingteam.ch property, not simy.ch's — so GA4 can't verify clicks on the `simy.ch/fl` SMS short-link.
- Logs each `/fl` redirect to a new `sms_link_clicks` table via a narrow `security definer` RPC (`log_sms_link_click`), so I can check click counts directly in the database going forward.
- The RPC only allows inserting into that one table — the publishable key used by the marketing site can't read/write anything else.
- Logging is fire-and-forget; failures never block the redirect.

## Test plan
- [x] Local smoke test passed (pre-push hook)
- [ ] Click `simy.ch/fl` after merge and confirm a row appears in `sms_link_clicks`

Made with [Cursor](https://cursor.com)