### PR TITLE
Persist FCM push tokens after login

### DIFF
--- a/composables/useNativePush.ts
+++ b/composables/useNativePush.ts
@@ -9,6 +9,37 @@ import { navigateTo } from '#app'
 
 let listenersBound = false
 let registerStarted = false
+let tokenPersisted = false
+let pendingToken: string | null = null
+let pendingPlatform = 'ios'
+
+async function persistPushToken(token: string, platform: string): Promise<boolean> {
+  pendingToken = token
+  pendingPlatform = platform
+  try {
+    const { getSupabase } = await import('~/utils/supabase')
+    const { data: { session } } = await getSupabase().auth.getSession()
+    if (!session?.access_token) return false
+
+    await $fetch('/api/push/register-token', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      body: { token, platform },
+    })
+    pendingToken = null
+    tokenPersisted = true
+    return true
+  } catch (e) {
+    console.warn('[Push] Token registration failed:', e)
+    return false
+  }
+}
+
+/** Call after login — FCM often fires before Supabase session is ready. */
+export async function flushPendingPushToken(): Promise<boolean> {
+  if (!pendingToken) return tokenPersisted
+  return persistPushToken(pendingToken, pendingPlatform)
+}
 
 export async function isCapacitorNative(): Promise<boolean> {
   if (import.meta.server) return false
@@ -31,22 +62,8 @@ async function bindPushListeners() {
   const { PushNotifications } = await import('@capacitor/push-notifications')
 
   await PushNotifications.addListener('registration', async (tokenData) => {
-    try {
-      const { getSupabase } = await import('~/utils/supabase')
-      const { data: { session } } = await getSupabase().auth.getSession()
-      if (!session?.access_token) return
-
-      await $fetch('/api/push/register-token', {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${session.access_token}` },
-        body: {
-          token: tokenData.value,
-          platform: (window as any).Capacitor?.getPlatform?.() || 'ios',
-        },
-      })
-    } catch (e) {
-      console.warn('[Push] Token registration failed:', e)
-    }
+    const platform = (window as any).Capacitor?.getPlatform?.() || 'ios'
+    await persistPushToken(tokenData.value, platform)
   })
 
   await PushNotifications.addListener('registrationError', (err) => {
@@ -113,7 +130,8 @@ export async function ensureNativePushRegistration(opts?: {
       return status.receive === 'denied' ? 'denied' : 'prompt'
     }
 
-    if (!registerStarted) {
+    await flushPendingPushToken()
+    if (!registerStarted || !tokenPersisted) {
       registerStarted = true
       await PushNotifications.register()
     }

--- a/plugins/push.client.ts
+++ b/plugins/push.client.ts
@@ -10,6 +10,7 @@ export default defineNuxtPlugin(() => {
   if (import.meta.server) return
 
   const tryRegister = () => {
+    void flushPendingPushToken()
     void ensureNativePushRegistration({ request: true })
   }
 


### PR DESCRIPTION
## Summary
- Keep the iOS/Android FCM token when it arrives before the Supabase session is ready, then save it as soon as the user is logged in.
- Re-register if the first attempt never persisted, so TestFlight devices show up in `push_tokens`.

Simy TestFlight is a hosted WebView (`app.simy.ch`). This ships with the next production deploy — no new native binary required.

## Test plan
- [ ] After merge, wait for Vercel production
- [ ] Open existing Simy TestFlight, stay logged in, fully kill the app, reopen
- [ ] Confirm a row appears in `push_tokens`
- [ ] Send a test push to that user; turn Focus/DND off to see the banner


Made with [Cursor](https://cursor.com)