### PR TITLE
Register push tokens after cookie login

### DIFF
--- a/composables/useNativePush.ts
+++ b/composables/useNativePush.ts
@@ -13,17 +13,28 @@ let tokenPersisted = false
 let pendingToken: string | null = null
 let pendingPlatform = 'ios'
 
+async function resolveAccessToken(): Promise<string | null> {
+  const { getSupabase } = await import('~/utils/supabase')
+  const { data: { session } } = await getSupabase().auth.getSession()
+  if (session?.access_token) return session.access_token
+  // Cookie login (staff/admin) often has no supabase-js session yet.
+  try {
+    const { refreshClientSession } = await import('~/utils/client-session-refresh')
+    const refreshed = await refreshClientSession()
+    return refreshed?.access_token || null
+  } catch {
+    return null
+  }
+}
+
 async function persistPushToken(token: string, platform: string): Promise<boolean> {
   pendingToken = token
   pendingPlatform = platform
   try {
-    const { getSupabase } = await import('~/utils/supabase')
-    const { data: { session } } = await getSupabase().auth.getSession()
-    if (!session?.access_token) return false
-
+    const accessToken = await resolveAccessToken()
     await $fetch('/api/push/register-token', {
       method: 'POST',
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      ...(accessToken ? { headers: { Authorization: `Bearer ${accessToken}` } } : {}),
       body: { token, platform },
     })
     pendingToken = null
@@ -49,7 +60,7 @@ export async function isCapacitorNative(): Promise<boolean> {
   } catch {
     /* bundle may load before the bridge */
   }
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < 60; i++) {
     if ((window as any).Capacitor?.isNativePlatform?.()) return true
     await new Promise(r => setTimeout(r, 50))
   }

--- a/plugins/push.client.ts
+++ b/plugins/push.client.ts
@@ -14,8 +14,11 @@ export default defineNuxtPlugin(() => {
     void ensureNativePushRegistration({ request: true })
   }
 
-  void (async () => {
+  let setupDone = false
+  const setup = async () => {
+    if (setupDone) return
     if (!(await isCapacitorNative())) return
+    setupDone = true
 
     try {
       const { getSupabase } = await import('~/utils/supabase')
@@ -39,5 +42,17 @@ export default defineNuxtPlugin(() => {
     } catch (e) {
       console.warn('[Push] Setup failed:', e)
     }
-  })()
+  }
+
+  void setup()
+  // Hosted WebView can inject Capacitor after the first JS tick; cookie
+  // login hydrates supabase-js a moment later. Keep trying briefly.
+  let attempts = 0
+  const iv = window.setInterval(() => {
+    attempts += 1
+    void setup()
+    tryRegister()
+    if (setupDone && attempts >= 8) window.clearInterval(iv)
+    if (attempts >= 15) window.clearInterval(iv)
+  }, 1000)
 })

--- a/server/api/push/register-token.post.ts
+++ b/server/api/push/register-token.post.ts
@@ -2,15 +2,13 @@
 // Saves (or refreshes) an FCM/APNs device token for the current user.
 // Called by plugins/push.client.ts after Capacitor PushNotifications.register().
 
-import { defineEventHandler, readBody, createError, getHeader } from 'h3'
-import { createClient } from '@supabase/supabase-js'
+import { defineEventHandler, readBody, createError } from 'h3'
+import { getAuthUserFromRequest } from '~/server/utils/auth-helper'
 import { getSupabaseAdmin } from '~/server/utils/supabase-admin'
 
 export default defineEventHandler(async (event) => {
-  const authHeader = getHeader(event, 'authorization') ?? ''
-  const accessToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
-
-  if (!accessToken) {
+  const authUser = await getAuthUserFromRequest(event)
+  if (!authUser?.id) {
     throw createError({ statusCode: 401, statusMessage: 'Nicht authentifiziert' })
   }
 
@@ -30,24 +28,12 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Ungültige Plattform' })
   }
 
-  // Resolve user from the access token
-  const supabaseUrl = process.env.SUPABASE_URL!
-  const supabaseAnonKey = process.env.SUPABASE_KEY!
-  const client = createClient(supabaseUrl, supabaseAnonKey, {
-    global: { headers: { Authorization: `Bearer ${accessToken}` } },
-  })
-  const { data: { user }, error: authError } = await client.auth.getUser()
-
-  if (authError || !user) {
-    throw createError({ statusCode: 401, statusMessage: 'Ungültiger Token' })
-  }
-
   // Map auth.users.id → public.users.id (sendPushToUser keys off app user id)
   const admin = getSupabaseAdmin()
   const { data: userData, error: userLookupError } = await admin
     .from('users')
     .select('id, tenant_id')
-    .eq('auth_user_id', user.id)
+    .eq('auth_user_id', authUser.id)
     .maybeSingle()
 
   if (userLookupError) {


### PR DESCRIPTION
## Summary
- `kilchi@drivingteam.ch` logged in on TestFlight, iOS permission is on, but `register-token` was never called.
- Staff login uses httpOnly cookies; `supabase.auth.getSession()` is often empty, so the client skipped the POST.
- Accept cookie auth on `/api/push/register-token`, hydrate the session via `refreshClientSession`, and retry native setup for a few seconds.

## Test plan
- [ ] After production deploy: open Simy TestFlight as kilchi@drivingteam.ch
- [ ] Kill and reopen, wait 15s
- [ ] Confirm a `push_tokens` row for that staff user
- [ ] Send a test push (Focus/DND off)


Made with [Cursor](https://cursor.com)