### PR TITLE
Fix Teilnehmerliste PDF upload for Zürich course names

### DIFF
--- a/components/CourseSessionRosterModal.vue
+++ b/components/CourseSessionRosterModal.vue
@@ -38,16 +38,35 @@
         </span>
         <button
           type="button"
-          class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold text-white disabled:opacity-40 transition-opacity hover:opacity-90"
+          class="appearance-none inline-flex items-center justify-center gap-1.5 min-w-[6.75rem] px-3 py-1.5 rounded-lg text-xs font-semibold text-white select-none touch-manipulation [-webkit-tap-highlight-color:transparent] disabled:opacity-40 hover:opacity-90"
+          :class="isPreparingPdf ? 'pointer-events-none opacity-70' : ''"
           :style="{ background: primaryColor }"
-          :disabled="isLoading || isPreparingPdf || allParticipants.length === 0"
+          :disabled="isLoading || allParticipants.length === 0"
+          :aria-busy="isPreparingPdf"
           title="Kurs-Teilnehmerliste (alle Teile) als PDF"
           @click="downloadPdf"
         >
-          <svg class="w-3.5 h-3.5" :class="isPreparingPdf ? 'animate-pulse' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg
+            v-if="isPreparingPdf"
+            class="w-3.5 h-3.5 flex-shrink-0 animate-spin"
+            fill="none"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" />
+            <path class="opacity-85" fill="currentColor" d="M4 12a8 8 0 018-8v3a5 5 0 00-5 5H4z" />
+          </svg>
+          <svg
+            v-else
+            class="w-3.5 h-3.5 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z" />
           </svg>
-          {{ isPreparingPdf ? 'PDF…' : 'PDF / Druck' }}
+          PDF / Druck
         </button>
       </div>
 
@@ -282,7 +301,10 @@ async function downloadPdf() {
       },
     })
   } catch (err: any) {
-    pdfError.value = err?.data?.statusMessage || err?.message || 'PDF konnte nicht geöffnet werden'
+    const serverMessage = err?.data?.statusMessage || err?.statusMessage
+    pdfError.value = serverMessage && !/Invalid key|upload failed|generation failed/i.test(serverMessage)
+      ? serverMessage
+      : 'Teilnehmerliste konnte nicht erstellt werden. Bitte erneut versuchen.'
   } finally {
     isPreparingPdf.value = false
   }

--- a/server/api/courses/participant-list-pdf.post.ts
+++ b/server/api/courses/participant-list-pdf.post.ts
@@ -114,8 +114,7 @@ export default defineEventHandler(async (event) => {
     await browser.close()
     browser = null
 
-    const safeCourse = String(roster.course.name || 'Kurs').replace(/[^\w.\-äöüÄÖÜß]+/g, '_')
-    const filename = `Teilnehmerliste_${safeCourse}.pdf`
+    const filename = `Teilnehmerliste_${roster.course.name || 'Kurs'}.pdf`
 
     const uploaded = await uploadPdfAndGetPublicUrl(supabase, {
       folder: 'participant-lists',
@@ -131,8 +130,8 @@ export default defineEventHandler(async (event) => {
     }
     logger.error('❌ Participant list PDF generation failed:', err)
     throw createError({
-      statusCode: 500,
-      statusMessage: `PDF generation failed: ${err?.message || 'unknown error'}`,
+      statusCode: err?.statusCode || 500,
+      statusMessage: err?.statusMessage || 'Teilnehmerliste konnte nicht erstellt werden',
     })
   }
 })

--- a/server/utils/__tests__/upload-pdf-public.test.ts
+++ b/server/utils/__tests__/upload-pdf-public.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPdfStoragePath,
+  isValidStorageKey,
+  sanitizeStorageFilename,
+} from '../upload-pdf-public'
+
+describe('sanitizeStorageFilename', () => {
+  it('transliterates umlauts so Zürich course names become valid storage keys', () => {
+    const name = sanitizeStorageFilename(
+      'Teilnehmerliste_Motorrad_Grundkurs_Zürich-Altstetten_-_29.08.2026.pdf'
+    )
+    expect(name).toBe('Teilnehmerliste_Motorrad_Grundkurs_Zuerich-Altstetten_-_29.08.2026.pdf')
+    expect(isValidStorageKey(`participant-lists/2026/08/uuid_${name}`)).toBe(true)
+  })
+
+  it('strips remaining accents and collapses junk characters', () => {
+    expect(sanitizeStorageFilename('Brief Genève / été.pdf')).toBe('Brief_Geneve_ete.pdf')
+    expect(sanitizeStorageFilename('  Rechnung #12 (Müller) .pdf  ')).toBe('Rechnung_12_Mueller.pdf')
+  })
+
+  it('keeps a usable fallback when the name is empty after sanitizing', () => {
+    expect(sanitizeStorageFilename('___')).toBe('file.bin')
+    expect(sanitizeStorageFilename('')).toBe('file.bin')
+  })
+})
+
+describe('buildPdfStoragePath', () => {
+  it('never uploads the production-failing Zürich key', () => {
+    const { filepath, filename } = buildPdfStoragePath(
+      'participant-lists',
+      'Teilnehmerliste_Motorrad_Grundkurs_Zürich-Altstetten_-_29.08.2026.pdf',
+      '7be38dda-9882-4efc-a2c6-b5e66813f9f7',
+      new Date('2026-08-24T08:00:00+02:00'),
+    )
+    expect(filename).toBe('Teilnehmerliste_Motorrad_Grundkurs_Zuerich-Altstetten_-_29.08.2026.pdf')
+    expect(filepath).toBe(
+      'participant-lists/2026/08/7be38dda-9882-4efc-a2c6-b5e66813f9f7_Teilnehmerliste_Motorrad_Grundkurs_Zuerich-Altstetten_-_29.08.2026.pdf',
+    )
+    expect(isValidStorageKey(filepath)).toBe(true)
+    expect(filepath.includes('ü')).toBe(false)
+  })
+})

--- a/server/utils/upload-pdf-public.ts
+++ b/server/utils/upload-pdf-public.ts
@@ -4,37 +4,103 @@
  * data:/blob: URLs do not work in SFSafariViewController / Chrome Custom Tabs.
  */
 import { createError } from 'h3'
+import { logger } from '~/utils/logger'
+
+const GERMAN_TRANSLIT: Record<string, string> = {
+  ä: 'ae',
+  ö: 'oe',
+  ü: 'ue',
+  Ä: 'Ae',
+  Ö: 'Oe',
+  Ü: 'Ue',
+  ß: 'ss',
+}
+
+// Mirrors supabase/storage `isValidKey` (ASCII / S3-safe object keys only).
+const SUPABASE_KEY_RE = /^[\w/!.\- *'()&$@=;:+,?]*$/
+
+export function isValidStorageKey(key: string): boolean {
+  return key.length > 0 && key.length <= 1024 && SUPABASE_KEY_RE.test(key)
+}
+
+function toAsciiSegment(value: string): string {
+  return String(value || '')
+    .replace(/[äöüÄÖÜß]/g, (ch) => GERMAN_TRANSLIT[ch] ?? '_')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\w.-]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^[._-]+|[._-]+$/g, '')
+}
+
+/**
+ * Supabase Storage rejects non-ASCII object keys (`InvalidKey`).
+ * Course names like "Zürich-Altstetten" used to keep the umlaut and fail on upload.
+ */
+export function sanitizeStorageFilename(filename: string): string {
+  const raw = String(filename || '').trim()
+  const lastDot = raw.lastIndexOf('.')
+  const hasExt = lastDot > 0 && lastDot < raw.length - 1
+  const ext = hasExt ? raw.slice(lastDot + 1) : ''
+  const base = hasExt ? raw.slice(0, lastDot) : raw
+
+  const safeBase = toAsciiSegment(base) || 'file'
+  const safeExt = (toAsciiSegment(ext).replace(/_/g, '') || 'bin')
+  return `${safeBase}.${safeExt}`
+}
+
+export function buildPdfStoragePath(
+  folder: string,
+  filename: string,
+  uniqueToken: string,
+  now = new Date(),
+): { filepath: string; filename: string } {
+  const safeName = sanitizeStorageFilename(filename)
+  const safeFolder = toAsciiSegment(folder) || 'files'
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const filepath = `${safeFolder}/${year}/${month}/${uniqueToken}_${safeName}`
+  if (isValidStorageKey(filepath)) {
+    return { filepath, filename: safeName }
+  }
+  return {
+    filepath: `${safeFolder}/${year}/${month}/${uniqueToken}.pdf`,
+    filename: safeName,
+  }
+}
 
 export async function uploadPdfAndGetPublicUrl(
   supabase: { storage: any },
   opts: { folder: string; filename: string; pdfBuffer: Buffer }
 ): Promise<{ pdfUrl: string; filename: string }> {
-  const safeName = opts.filename.replace(/[^\w.\-äöüÄÖÜß]+/g, '_').replace(/_+/g, '_')
-  const year = new Date().getFullYear()
-  const month = String(new Date().getMonth() + 1).padStart(2, '0')
   // ✅ SECURITY: filenames derived from user-facing data (invoice numbers, student names,
   // dates, ...) can collide across different requests/customers/tenants. Since uploads use
   // upsert: true, a collision silently overwrites the other document at the same public URL,
   // letting one customer end up downloading someone else's PDF. A random, unguessable token
   // guarantees every upload gets its own path, regardless of what filename was requested.
   const uniqueToken = crypto.randomUUID()
-  const filepath = `${opts.folder}/${year}/${month}/${uniqueToken}_${safeName}`
+  const { filepath, filename: safeName } = buildPdfStoragePath(
+    opts.folder,
+    opts.filename,
+    uniqueToken,
+  )
 
   const { error: uploadError } = await supabase.storage
     .from('receipts')
     .upload(filepath, opts.pdfBuffer, { contentType: 'application/pdf', upsert: true })
 
   if (uploadError) {
+    logger.error('PDF upload failed:', uploadError.message)
     throw createError({
       statusCode: 500,
-      statusMessage: `PDF upload failed: ${uploadError.message}`,
+      statusMessage: 'PDF konnte nicht gespeichert werden',
     })
   }
 
   const { data: publicData } = supabase.storage.from('receipts').getPublicUrl(filepath)
   const pdfUrl = publicData?.publicUrl
   if (!pdfUrl) {
-    throw createError({ statusCode: 500, statusMessage: 'PDF public URL missing' })
+    throw createError({ statusCode: 500, statusMessage: 'PDF konnte nicht gespeichert werden' })
   }
 
   return { pdfUrl, filename: safeName }


### PR DESCRIPTION
## Summary
- Supabase Storage rejects non-ASCII object keys, so participant-list PDFs for courses like **Zürich-Altstetten** fail with `Invalid key` on TestFlight/production.
- Transliterate umlauts (`ü` → `ue`) before upload, fall back to a UUID path if a key is still invalid, and stop leaking raw storage errors in the roster modal.
- Keep the **PDF / Druck** button width stable on iOS tap so the loading state no longer overlaps itself.

## Test plan
- [ ] Open a Motorrad Grundkurs Zürich-Altstetten in the staff calendar roster modal
- [ ] Tap **PDF / Druck** — button stays one pill with a spinner (no second overlapping button)
- [ ] PDF opens; no `Invalid key` / `PDF generation failed` banner
- [ ] Repeat for a course name without umlauts (still works)
- [ ] After merge/deploy, re-test the same flow on TestFlight


Made with [Cursor](https://cursor.com)