### PR TITLE
Ask for push permission only after login

### DIFF
--- a/plugins/push.client.ts
+++ b/plugins/push.client.ts
@@ -9,16 +9,28 @@ import { defineNuxtPlugin } from '#imports'
 export default defineNuxtPlugin(() => {
   if (import.meta.server) return
 
-  const tryRegister = () => {
-    void flushPendingPushToken()
-    void ensureNativePushRegistration({ request: true })
+  const isLoggedIn = () => {
+    try {
+      return Boolean(useAuthStore().isLoggedIn)
+    } catch {
+      return false
+    }
   }
 
-  let setupDone = false
+  const tryRegister = () => {
+    void flushPendingPushToken()
+    // Never show the OS dialog on the login screen.
+    void ensureNativePushRegistration({ request: isLoggedIn() })
+  }
+
+  let setupStarted = false
   const setup = async () => {
-    if (setupDone) return
-    if (!(await isCapacitorNative())) return
-    setupDone = true
+    if (setupStarted) return
+    setupStarted = true
+    if (!(await isCapacitorNative())) {
+      setupStarted = false
+      return
+    }
 
     try {
       const { getSupabase } = await import('~/utils/supabase')
@@ -51,8 +63,8 @@ export default defineNuxtPlugin(() => {
   const iv = window.setInterval(() => {
     attempts += 1
     void setup()
-    tryRegister()
-    if (setupDone && attempts >= 8) window.clearInterval(iv)
+    if (isLoggedIn()) tryRegister()
+    if (setupStarted && attempts >= 8) window.clearInterval(iv)
     if (attempts >= 15) window.clearInterval(iv)
   }, 1000)
 })


### PR DESCRIPTION
## Summary
- Fixes Bugbot on #64: the retry interval no longer calls `requestPermissions()` on the login screen.
- `setup()` now takes a lock before awaiting Capacitor, so auth listeners are not registered twice.

## Test plan
- [ ] Cold-open TestFlight on the login screen — no iOS/Android notification dialog
- [ ] After login, permission request / token persist still runs
- [ ] Confirm a `push_tokens` row after kill + reopen while logged in


Made with [Cursor](https://cursor.com)