### PR TITLE
Fix Simy checkout when SMS overage price has no Billing Meter

### DIFF
--- a/pages/upgrade.vue
+++ b/pages/upgrade.vue
@@ -1260,7 +1260,7 @@ const startCheckout = async () => {
       showAuthPrompt.value = true
       return
     }
-    error.value = err?.data?.statusMessage || 'Checkout konnte nicht gestartet werden.'
+    error.value = err?.data?.statusMessage || err?.statusMessage || err?.data?.message || 'Checkout konnte nicht gestartet werden.'
   } finally {
     loading.value = false
   }

--- a/server/api/stripe/create-checkout-session.post.ts
+++ b/server/api/stripe/create-checkout-session.post.ts
@@ -250,7 +250,7 @@ export default defineEventHandler(async (event) => {
     : `${baseUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}`
 
   try {
-    const session = await stripe.checkout.sessions.create({
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: 'subscription',
       customer: stripeCustomerId,
       line_items: lineItems,
@@ -277,9 +277,22 @@ export default defineEventHandler(async (event) => {
       } : {}),
       success_url: successUrl,
       cancel_url: `${baseUrl}/upgrade`,
-    })
+    }
 
-    return { id: session.id, url: session.url }
+    try {
+      const session = await stripe.checkout.sessions.create(sessionParams)
+      return { id: session.id, url: session.url }
+    } catch (firstErr: any) {
+      // Legacy metered SMS price (no Billing Meter) 502s the whole checkout.
+      const firstMsg = String(firstErr?.message || '')
+      if (smsLine && /meter/i.test(firstMsg)) {
+        console.warn('⚠️ Retrying checkout without SMS overage line:', firstMsg)
+        sessionParams.line_items = lineItems.filter(item => item.price !== smsLine.price)
+        const session = await stripe.checkout.sessions.create(sessionParams)
+        return { id: session.id, url: session.url }
+      }
+      throw firstErr
+    }
   } catch (stripeErr: any) {
     console.error('❌ Stripe checkout.sessions.create failed', {
       type: stripeErr?.type,
@@ -292,7 +305,14 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 502,
       statusMessage: `Stripe-Fehler (${stripeErr?.type || 'unknown'}): ${stripeErr?.message || 'Checkout konnte nicht erstellt werden'}`,
-      data: { stripe: true, type: stripeErr?.type, code: stripeErr?.code, keyMode, planPriceId },
+      data: {
+        stripe: true,
+        type: stripeErr?.type,
+        code: stripeErr?.code,
+        keyMode,
+        planPriceId,
+        statusMessage: `Stripe-Fehler (${stripeErr?.type || 'unknown'}): ${stripeErr?.message || 'Checkout konnte nicht erstellt werden'}`,
+      },
     })
   }
 })

--- a/server/api/stripe/update-subscription.post.ts
+++ b/server/api/stripe/update-subscription.post.ts
@@ -182,7 +182,12 @@ export default defineEventHandler(async (event) => {
   let smsOveragePriceId = getSmsOveragePriceId()
   if (smsOveragePriceId) {
     try {
-      await stripe.prices.retrieve(smsOveragePriceId)
+      const smsPrice = await stripe.prices.retrieve(smsOveragePriceId)
+      const { isBasilCompatibleRecurringPrice } = await import('~/server/utils/sms-stripe')
+      if (!isBasilCompatibleRecurringPrice(smsPrice)) {
+        console.warn('⚠️ Skipping SMS overage item — metered price has no Billing Meter (Basil)')
+        smsOveragePriceId = undefined
+      }
     } catch (err: any) {
       console.warn('⚠️ Skipping SMS overage item — price not in current Stripe mode:', err?.message)
       smsOveragePriceId = undefined

--- a/server/utils/__tests__/sms-stripe.test.ts
+++ b/server/utils/__tests__/sms-stripe.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { isBasilCompatibleRecurringPrice } from '~/server/utils/sms-stripe'
+
+describe('isBasilCompatibleRecurringPrice', () => {
+  it('accepts licensed recurring prices', () => {
+    expect(isBasilCompatibleRecurringPrice({
+      recurring: { usage_type: 'licensed', meter: null },
+    })).toBe(true)
+  })
+
+  it('accepts metered prices that have a Billing Meter', () => {
+    expect(isBasilCompatibleRecurringPrice({
+      recurring: { usage_type: 'metered', meter: 'mtr_123' },
+    })).toBe(true)
+  })
+
+  it('rejects legacy metered prices without a meter (Basil checkout 502)', () => {
+    expect(isBasilCompatibleRecurringPrice({
+      recurring: { usage_type: 'metered', meter: null },
+    })).toBe(false)
+    expect(isBasilCompatibleRecurringPrice({
+      recurring: { usage_type: 'metered' },
+    })).toBe(false)
+  })
+
+  it('rejects missing prices', () => {
+    expect(isBasilCompatibleRecurringPrice(null)).toBe(false)
+    expect(isBasilCompatibleRecurringPrice(undefined)).toBe(false)
+  })
+})

--- a/server/utils/sms-stripe.ts
+++ b/server/utils/sms-stripe.ts
@@ -157,9 +157,23 @@ export function smsOverageCheckoutLineItem(): Stripe.Checkout.SessionCreateParam
 }
 
 /**
+ * Basil+ (2025-03-31 onward) cannot attach a metered price that has no Billing
+ * Meter. A leftover legacy `usage_type=metered` price will 502 Checkout.
+ */
+export function isBasilCompatibleRecurringPrice(price: {
+  recurring?: { usage_type?: string | null; meter?: string | null } | null
+} | null | undefined): boolean {
+  if (!price) return false
+  const usage = price.recurring?.usage_type
+  if (usage === 'metered' && !price.recurring?.meter) return false
+  return true
+}
+
+/**
  * Like smsOverageCheckoutLineItem, but verifies the price exists in the current
- * Stripe mode (test vs live). Prevents checkout 502 when .env has a live SMS
- * price while STRIPE_SECRET_KEY is sk_test_… (or vice versa).
+ * Stripe mode (test vs live) AND is attachable on Basil. Prevents checkout 502
+ * when .env has a live SMS price while STRIPE_SECRET_KEY is sk_test_… — or when
+ * the configured price is a legacy metered price without a meter.
  */
 export async function smsOverageCheckoutLineItemSafe(): Promise<Stripe.Checkout.SessionCreateParams.LineItem | null> {
   const line = smsOverageCheckoutLineItem()
@@ -169,7 +183,13 @@ export async function smsOverageCheckoutLineItemSafe(): Promise<Stripe.Checkout.
   if (!stripe) return null
 
   try {
-    await stripe.prices.retrieve(line.price)
+    const price = await stripe.prices.retrieve(line.price)
+    if (!isBasilCompatibleRecurringPrice(price)) {
+      logger.warn('⚠️ Skipping SMS overage checkout line — metered price has no Billing Meter (Basil):', {
+        priceId: line.price,
+      })
+      return null
+    }
     return line
   } catch (err: any) {
     logger.warn('⚠️ Skipping SMS overage checkout line — price not available in current Stripe mode:', {


### PR DESCRIPTION
## Summary
- Skip the SMS overage Checkout line if the Stripe price is still a legacy metered price (no Billing Meter), so tenants like Gemperli can subscribe.
- Retry Checkout without that line if Stripe still errors on `meter`.
- Surface the real Stripe error on `/upgrade`.

The live SMS price is now linked to meter `SMS-Überzug` (`sms_overage_segments`). This change is a safety net so a missing meter cannot 502 the whole subscription again.

## Test plan
- [ ] `/upgrade` Checkout with Professional + extra seats (no Wallee) starts Stripe Checkout
- [ ] SMS overage line is included now that the meter is attached
- [ ] Error banner shows the Stripe message if Checkout fails for another reason

Made with [Cursor](https://cursor.com)