### PR TITLE
Bump Simy iOS version to 1.1.1

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = ch.simy.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -346,7 +346,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = ch.simy.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>202606081347</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/App/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/App/ci_scripts/ci_pre_xcodebuild.sh
@@ -18,6 +18,7 @@ BUILD_NUMBER="$(date +%Y%m%d%H%M)"
 
 REPO_ROOT="${CI_PRIMARY_REPOSITORY_PATH:-$CI_WORKSPACE}"
 INFO_PLIST="$REPO_ROOT/ios/App/App/Info.plist"
+CONFIG="$REPO_ROOT/clients/simy/config.json"
 
 echo "🔢 Setting CFBundleVersion to $BUILD_NUMBER in $INFO_PLIST"
 
@@ -27,5 +28,15 @@ if [ ! -f "$INFO_PLIST" ]; then
 fi
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$INFO_PLIST"
+
+# Apple closes a version train after App Store approval. Stamp the marketing
+# version from clients/simy/config.json so Xcode Cloud cannot resubmit 1.0.1.
+if [ -f "$CONFIG" ]; then
+  MARKETING_VERSION="$(python3 -c "import json; print(json.load(open('$CONFIG')).get('version') or '')")"
+  if [ -n "$MARKETING_VERSION" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $MARKETING_VERSION" "$INFO_PLIST"
+    echo "✅ CFBundleShortVersionString is now: $MARKETING_VERSION"
+  fi
+fi
 
 echo "✅ CFBundleVersion is now: $(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"


### PR DESCRIPTION
## Summary
- App Store already approved Simy **1.0.1**, so Xcode Cloud build 502 was rejected (ITMS-90186 / ITMS-90062).
- Stamp marketing version **1.1.1** in Info.plist and the Xcode project (matches `clients/simy/config.json`).
- Xcode Cloud now copies that version from the Simy config before archive, so an approved train cannot be reused.

## Test plan
- [ ] After merge, Xcode Cloud uploads a build as version 1.1.1 (not 1.0.1)
- [ ] TestFlight shows the new 1.1.1 build without ITMS-90186


Made with [Cursor](https://cursor.com)