### PR TITLE
Attach Simy receipt PDF to subscription payment emails

### DIFF
--- a/server/api/stripe/webhook.post.ts
+++ b/server/api/stripe/webhook.post.ts
@@ -5,6 +5,10 @@ import {
 } from '~/utils/planFeatures'
 import { syncFeatureFlags } from '~/server/utils/syncFeatureFlags'
 import { sendEmail } from '~/server/utils/email'
+import {
+  generateSimySubscriptionReceiptPdfSafe,
+  receiptLinesFromStripe,
+} from '~/server/utils/simy-subscription-receipt-pdf'
 import { resolveSubscriptionPeriodEnd } from '~/server/utils/stripe-subscription-period'
 
 export default defineEventHandler(async (event) => {
@@ -513,22 +517,6 @@ function formatChf(amountCents: number): string {
   return (amountCents / 100).toFixed(2)
 }
 
-/** Translate common Stripe English proration/line phrases to German for the email. */
-function localizeInvoiceLineDescription(description: string | null | undefined): string {
-  if (!description) return 'Position'
-  let d = description
-  d = d.replace(/^Unused time on /i, 'Nicht genutzte Zeit: ')
-  d = d.replace(/^Remaining time on /i, 'Anteilige Restzeit: ')
-  d = d.replace(/ after (\d{1,2} \w+ \d{4})/i, ' ab $1')
-  d = d.replace(/\b1 Fahrlehrer Login\b/gi, 'Extra Fahrlehrer-Seat')
-  d = d.replace(/\bGoogle Business Profile Add-on\b/gi, 'Google Business Profile')
-  d = d.replace(/\bEnterprise\b/g, 'Enterprise')
-  d = d.replace(/\bProfessional\b/g, 'Professional')
-  d = d.replace(/\bStarter\b/g, 'Starter')
-  d = d.replace(/\(at CHF ([\d.]+) \/ month\)/gi, '(CHF $1 / Mt.)')
-  d = d.replace(/^(\d+) × /g, '$1 × ')
-  return d
-}
 
 function isProrationLine(line: Stripe.InvoiceLineItem): boolean {
   if ((line as any).proration === true) return true
@@ -576,7 +564,7 @@ async function sendPaymentConfirmationEmail(
 
   const { data: tenant } = await supabase
     .from('tenants')
-    .select('name, contact_email, subscription_plan, current_period_end, addon_seats, addon_courses_enabled, addon_affiliate_enabled, addon_gbp_enabled')
+    .select('name, contact_email, subscription_plan, current_period_end, addon_seats, addon_courses_enabled, addon_affiliate_enabled, addon_gbp_enabled, invoice_street, invoice_street_nr, invoice_zip, invoice_city, legal_company_name')
     .eq('id', tenantId)
     .single()
 
@@ -618,11 +606,12 @@ async function sendPaymentConfirmationEmail(
 
   const renderLineRows = (items: Stripe.InvoiceLineItem[]) =>
     items.map(line => {
-      const label = localizeInvoiceLineDescription(line.description)
-      const qty = line.quantity && line.quantity > 1 ? ` × ${line.quantity}` : ''
+      const mapped = receiptLinesFromStripe([line])[0]
+      if (!mapped) return ''
+      const qty = mapped.quantity > 1 ? ` × ${mapped.quantity}` : ''
       return `<tr>
-                <td style="padding:10px 16px;font-size:14px;color:#374151;border-bottom:1px solid #f3f4f6">${label}${qty}</td>
-                ${renderAmountCell(line.amount)}
+                <td style="padding:10px 16px;font-size:14px;color:#374151;border-bottom:1px solid #f3f4f6">${mapped.product_name}${qty}</td>
+                ${renderAmountCell(mapped.total_price_rappen)}
               </tr>`
     }).join('')
 
@@ -644,10 +633,32 @@ async function sendPaymentConfirmationEmail(
               </tr>
             </table>` : ''
 
+  const paidAtUnix = (invoice.status_transitions as any)?.paid_at
+    || invoice.created
+    || Math.floor(Date.now() / 1000)
+  const vatAmountRappen = invoice.tax || 0
+  const receiptItems = receiptLinesFromStripe(lines)
+  const receiptNumber = invoice.number || invoice.id
+  const pdfBuffer = await generateSimySubscriptionReceiptPdfSafe({
+    invoiceNumber: receiptNumber,
+    paidAt: new Date(paidAtUnix * 1000),
+    customerName: tenant.legal_company_name || tenant.name || tenantName,
+    customerStreet: [tenant.invoice_street, tenant.invoice_street_nr].filter(Boolean).join(' '),
+    customerZip: tenant.invoice_zip || '',
+    customerCity: tenant.invoice_city || '',
+    customerEmail: tenant.contact_email,
+    items: receiptItems,
+    totalRappen: invoice.amount_paid,
+    vatAmountRappen,
+  })
+
   await sendEmail({
     to: tenant.contact_email,
     senderName: 'Simy',
     subject: `✅ Zahlung bestätigt – CHF ${amountCHF}`,
+    attachments: pdfBuffer
+      ? [{ filename: `Quittung_${receiptNumber}.pdf`, content: pdfBuffer }]
+      : undefined,
     html: `<!DOCTYPE html>
 <html lang="de"><head><meta charset="UTF-8"></head>
 <body style="margin:0;padding:0;background:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">
@@ -655,14 +666,14 @@ async function sendPaymentConfirmationEmail(
     <tr><td align="center">
       <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px">
         <tr><td style="background:#fff;border-radius:12px;overflow:hidden;box-shadow:0 4px 16px rgba(0,0,0,.08)">
-          <div style="background:linear-gradient(135deg,#16a34a,#15803d);padding:32px;border-radius:12px 12px 0 0;text-align:center">
+          <div style="background:linear-gradient(135deg,#6000BD,#8B2FE8);padding:32px;border-radius:12px 12px 0 0;text-align:center">
             <h1 style="margin:0;color:#fff;font-size:20px;font-weight:700">Zahlung erfolgreich</h1>
             <p style="margin:8px 0 0;color:rgba(255,255,255,.85);font-size:22px;font-weight:700">CHF ${amountCHF}</p>
           </div>
           <div style="padding:32px">
-            <p style="color:#111827;font-size:15px;margin:0 0 16px">Hallo <strong>${tenantName}</strong>,</p>
+            <p style="color:#111827;font-size:15px;margin:0 0 16px">Guten Tag</p>
             <p style="color:#4b5563;font-size:15px;line-height:1.6;margin:0 0 24px">
-              deine Simy-Abonnementzahlung von <strong>CHF ${amountCHF}</strong> wurde erfolgreich verarbeitet. Danke!
+              Ihre Simy-Abonnementzahlung von <strong>CHF ${amountCHF}</strong> wurde erfolgreich verarbeitet. Die Quittung finden Sie im Anhang.
             </p>
             ${positionsHtml}
             <table cellpadding="0" cellspacing="0" width="100%" style="border:1px solid #e5e7eb;border-radius:8px;overflow:hidden;margin:0 0 24px">
@@ -689,7 +700,7 @@ async function sendPaymentConfirmationEmail(
             <table width="100%" cellpadding="0" cellspacing="0"><tr>
               <td align="center" style="padding:8px 0 24px">
                 <a href="${baseUrl}/admin/billing"
-                   style="display:inline-block;background:linear-gradient(135deg,#16a34a,#15803d);color:#fff;text-decoration:none;padding:12px 32px;border-radius:8px;font-size:14px;font-weight:600">
+                   style="display:inline-block;background:linear-gradient(135deg,#6000BD,#8B2FE8);color:#fff;text-decoration:none;padding:12px 32px;border-radius:8px;font-size:14px;font-weight:600">
                   Abonnement verwalten →
                 </a>
               </td>

--- a/server/utils/__tests__/simy-subscription-receipt-pdf.test.ts
+++ b/server/utils/__tests__/simy-subscription-receipt-pdf.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  localizeInvoiceLineDescription,
+  receiptLineFromStripe,
+  receiptLinesFromStripe,
+} from '~/server/utils/simy-subscription-receipt-pdf'
+
+describe('simy subscription receipt lines', () => {
+  it('localizes seats and SMS labels', () => {
+    expect(localizeInvoiceLineDescription('2 × Extra Fahrlehrer-Seat (at CHF 19.00 / month)'))
+      .toBe('2 × Extra Fahrlehrer-Seat (CHF 19.00 / Mt.)')
+    expect(localizeInvoiceLineDescription('0 × Metered SMS Price (at CHF 0.15 / month)'))
+      .toContain('SMS-Überzug')
+  })
+
+  it('drops zero-amount metered SMS lines', () => {
+    expect(receiptLineFromStripe({
+      description: '0 × Metered SMS Price (at CHF 0.15 / month)',
+      amount: 0,
+      quantity: 0,
+    })).toBeNull()
+  })
+
+  it('does not double quantity in the product name', () => {
+    const line = receiptLineFromStripe({
+      description: '2 × Extra Fahrlehrer-Seat (at CHF 19.00 / month)',
+      amount: 3800,
+      quantity: 2,
+    })
+    expect(line).toEqual({
+      product_name: 'Extra Fahrlehrer-Seat (CHF 19.00 / Mt.)',
+      quantity: 2,
+      unit_price_rappen: 1900,
+      total_price_rappen: 3800,
+    })
+  })
+
+  it('keeps professional plan line', () => {
+    const lines = receiptLinesFromStripe([
+      { description: '1 × Professional (at CHF 149.00 / month)', amount: 14900, quantity: 1 },
+      { description: '0 × Metered SMS Price (at CHF 0.15 / month)', amount: 0, quantity: 0 },
+    ])
+    expect(lines).toHaveLength(1)
+    expect(lines[0].product_name).toContain('Professional')
+  })
+})

--- a/server/utils/simy-subscription-receipt-pdf.ts
+++ b/server/utils/simy-subscription-receipt-pdf.ts
@@ -1,0 +1,137 @@
+import { generateInvoicePdf } from '~/server/utils/invoice-pdf'
+import { loadTenantLogoForPdf } from '~/server/utils/tenant-logo-for-pdf'
+import { logger } from '~/utils/logger'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export const SIMY_ISSUER = {
+  name: 'Simy IT Systems Kilchenmann',
+  street: 'Weiherweg 2',
+  zip: '8610',
+  city: 'Uster',
+  email: 'info@simy.ch',
+  contactPerson: 'Pascal Kilchenmann',
+  primaryColor: '#6000BD',
+  secondaryColor: '#8B2FE8',
+}
+
+const SIMY_LOGO_URL = 'https://simy.ch/simy-logo.png'
+
+export interface StripeReceiptLine {
+  description: string | null
+  amount: number
+  quantity?: number | null
+}
+
+export interface ReceiptPdfLine {
+  product_name: string
+  quantity: number
+  unit_price_rappen: number
+  total_price_rappen: number
+}
+
+/** Translate Stripe invoice line copy and drop empty metered $0 rows. */
+export function localizeInvoiceLineDescription(description: string | null | undefined): string {
+  if (!description) return 'Position'
+  let d = description
+  d = d.replace(/^Unused time on /i, 'Nicht genutzte Zeit: ')
+  d = d.replace(/^Remaining time on /i, 'Anteilige Restzeit: ')
+  d = d.replace(/ after (\d{1,2} \w+ \d{4})/i, ' ab $1')
+  d = d.replace(/\b1 Fahrlehrer Login\b/gi, 'Extra Fahrlehrer-Seat')
+  d = d.replace(/\bGoogle Business Profile Add-on\b/gi, 'Google Business Profile')
+  d = d.replace(/Metered SMS Price/gi, 'SMS-Überzug')
+  d = d.replace(/\(at CHF ([\d.]+) \/ month\)/gi, '(CHF $1 / Mt.)')
+  return d
+}
+
+export function receiptLineFromStripe(line: StripeReceiptLine): ReceiptPdfLine | null {
+  const amount = line.amount ?? 0
+  const qty = Math.max(1, line.quantity || 1)
+  const raw = localizeInvoiceLineDescription(line.description)
+  if (amount === 0 && /sms|metered/i.test(raw)) return null
+
+  const qtyPrefix = new RegExp(`^${qty}\\s*[×x]\\s*`, 'i')
+  const product_name = raw.replace(qtyPrefix, '').trim() || raw
+  return {
+    product_name,
+    quantity: qty,
+    unit_price_rappen: Math.round(amount / qty),
+    total_price_rappen: amount,
+  }
+}
+
+export function receiptLinesFromStripe(lines: StripeReceiptLine[]): ReceiptPdfLine[] {
+  return lines.map(receiptLineFromStripe).filter((l): l is ReceiptPdfLine => !!l)
+}
+
+async function loadSimyLogoBase64(): Promise<string | null> {
+  const fromUrl = await loadTenantLogoForPdf(SIMY_LOGO_URL)
+  if (fromUrl?.base64) return fromUrl.base64
+  try {
+    const local = await readFile(resolve(process.cwd(), 'apps/simy/public/simy-logo.png'))
+    const converted = await loadTenantLogoForPdf(`data:image/png;base64,${local.toString('base64')}`)
+    return converted?.base64 || null
+  } catch {
+    return null
+  }
+}
+
+export async function generateSimySubscriptionReceiptPdf(opts: {
+  invoiceNumber: string
+  paidAt: Date
+  customerName: string
+  customerStreet?: string
+  customerZip?: string
+  customerCity?: string
+  customerEmail?: string
+  items: ReceiptPdfLine[]
+  totalRappen: number
+  vatAmountRappen?: number
+  vatRate?: number
+}): Promise<Buffer> {
+  const logo = await loadSimyLogoBase64()
+  const paidIso = opts.paidAt.toISOString().slice(0, 10)
+
+  return generateInvoicePdf({
+    documentTitle: 'QUITTUNG',
+    invoiceNumber: opts.invoiceNumber,
+    invoiceDate: paidIso,
+    dueDate: paidIso,
+    dateLabel: 'Quittungsdatum',
+    dueLabel: 'Bezahlt am',
+    tenantName: SIMY_ISSUER.name,
+    tenantStreet: SIMY_ISSUER.street,
+    tenantZip: SIMY_ISSUER.zip,
+    tenantCity: SIMY_ISSUER.city,
+    tenantEmail: SIMY_ISSUER.email,
+    tenantContactPerson: SIMY_ISSUER.contactPerson,
+    tenantLogoBase64: logo,
+    tenantLogoFormat: logo ? 'png' : undefined,
+    customerName: opts.customerName,
+    billingStreet: opts.customerStreet || '',
+    billingZip: opts.customerZip || '',
+    billingCity: opts.customerCity || '',
+    billingEmail: opts.customerEmail,
+    items: opts.items,
+    subtotalRappen: opts.totalRappen - (opts.vatAmountRappen || 0),
+    vatRate: opts.vatRate || 0,
+    vatAmountRappen: opts.vatAmountRappen || 0,
+    totalRappen: opts.totalRappen,
+    primaryColor: SIMY_ISSUER.primaryColor,
+    secondaryColor: SIMY_ISSUER.secondaryColor,
+    paymentBlockTitle: ' ',
+    paymentTerms: 'Vielen Dank für Ihr Vertrauen!\n\nFreundliche Grüsse\nPascal Kilchenmann',
+    introText: 'Wir bestätigen den Eingang Ihrer Simy-Abonnementzahlung.',
+  })
+}
+
+export async function generateSimySubscriptionReceiptPdfSafe(
+  opts: Parameters<typeof generateSimySubscriptionReceiptPdf>[0],
+): Promise<Buffer | null> {
+  try {
+    return await generateSimySubscriptionReceiptPdf(opts)
+  } catch (err: any) {
+    logger.warn('⚠️ Simy subscription receipt PDF failed (non-fatal):', err?.message || err)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Payment confirmation emails now attach a Swiss-invoice-style Quittung PDF (Simy branding, formal Sie).
- Zero-amount SMS overage lines are omitted; extra seats are not double-counted.

## Test plan
- [ ] After deploy, a paid Stripe subscription invoice sends the new mail + PDF
- [ ] Gemperli already received a one-off send of this version

Made with [Cursor](https://cursor.com)