### PR TITLE
Use UUID-only storage keys for participant-list PDFs

### DIFF
--- a/server/api/courses/participant-list-pdf.post.ts
+++ b/server/api/courses/participant-list-pdf.post.ts
@@ -67,6 +67,9 @@ export default defineEventHandler(async (event) => {
   let launchOptions: any
   if (isProduction) {
     const chromium = await getChromium()
+    if (typeof chromium.setGraphicsMode === 'function') {
+      chromium.setGraphicsMode(false)
+    }
     launchOptions = {
       args: chromium.args,
       defaultViewport: chromium.defaultViewport,
@@ -129,9 +132,13 @@ export default defineEventHandler(async (event) => {
       try { await browser.close() } catch { /* ignore */ }
     }
     logger.error('❌ Participant list PDF generation failed:', err)
+    const statusMessage = err?.statusMessage
+      || (err?.message && !/Invalid key|upload failed/i.test(err.message)
+        ? 'Teilnehmerliste konnte nicht gerendert werden'
+        : 'Teilnehmerliste konnte nicht erstellt werden')
     throw createError({
       statusCode: err?.statusCode || 500,
-      statusMessage: err?.statusMessage || 'Teilnehmerliste konnte nicht erstellt werden',
+      statusMessage,
     })
   }
 })

--- a/server/utils/__tests__/upload-pdf-public.test.ts
+++ b/server/utils/__tests__/upload-pdf-public.test.ts
@@ -26,7 +26,7 @@ describe('sanitizeStorageFilename', () => {
 })
 
 describe('buildPdfStoragePath', () => {
-  it('never uploads the production-failing Zürich key', () => {
+  it('keeps the object key ASCII-only and free of the course name', () => {
     const { filepath, filename } = buildPdfStoragePath(
       'participant-lists',
       'Teilnehmerliste_Motorrad_Grundkurs_Zürich-Altstetten_-_29.08.2026.pdf',
@@ -34,10 +34,9 @@ describe('buildPdfStoragePath', () => {
       new Date('2026-08-24T08:00:00+02:00'),
     )
     expect(filename).toBe('Teilnehmerliste_Motorrad_Grundkurs_Zuerich-Altstetten_-_29.08.2026.pdf')
-    expect(filepath).toBe(
-      'participant-lists/2026/08/7be38dda-9882-4efc-a2c6-b5e66813f9f7_Teilnehmerliste_Motorrad_Grundkurs_Zuerich-Altstetten_-_29.08.2026.pdf',
-    )
+    expect(filepath).toBe('participant-lists/2026/08/7be38dda-9882-4efc-a2c6-b5e66813f9f7.pdf')
     expect(isValidStorageKey(filepath)).toBe(true)
     expect(filepath.includes('ü')).toBe(false)
+    expect(filepath.includes('Zuerich')).toBe(false)
   })
 })

--- a/server/utils/upload-pdf-public.ts
+++ b/server/utils/upload-pdf-public.ts
@@ -59,14 +59,11 @@ export function buildPdfStoragePath(
   const safeFolder = toAsciiSegment(folder) || 'files'
   const year = now.getFullYear()
   const month = String(now.getMonth() + 1).padStart(2, '0')
-  const filepath = `${safeFolder}/${year}/${month}/${uniqueToken}_${safeName}`
-  if (isValidStorageKey(filepath)) {
-    return { filepath, filename: safeName }
-  }
-  return {
-    filepath: `${safeFolder}/${year}/${month}/${uniqueToken}.pdf`,
-    filename: safeName,
-  }
+  // Never put user-facing names in the object key. Course titles like
+  // "Zürich-Altstetten" used to fail Supabase `isValidKey` even after
+  // light sanitizing. The download name stays human-readable separately.
+  const filepath = `${safeFolder}/${year}/${month}/${uniqueToken}.pdf`
+  return { filepath, filename: safeName }
 }
 
 export async function uploadPdfAndGetPublicUrl(


### PR DESCRIPTION
## Summary
- Production still has **zero** successful `participant-lists/` uploads. The last failure (11:25) was `Invalid key` with `Zürich` in the path; after the umlaut deploy (11:41) no new upload reached Storage.
- Stop embedding course names in the object key. Store as `participant-lists/YYYY/MM/<uuid>.pdf` and keep the readable name only as the download filename.
- Return a clearer render-vs-save error if Chrome/PDF generation fails after a cold deploy.

## Test plan
- [ ] On TestFlight, open Motorrad Grundkurs Zürich-Altstetten and tap PDF
- [ ] Confirm a file appears under Storage `receipts/participant-lists/`
- [ ] PDF opens in the in-app browser
- [ ] Invoice/dunning PDFs still upload as before


Made with [Cursor](https://cursor.com)